### PR TITLE
Prevent statsd-client from crashing when ip address is not resolvable from host name

### DIFF
--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -14,7 +14,7 @@ namespace StatsdClient
         private Socket UDPSocket { get; set; }
         private string Name { get; set; }
         private int Port { get; set; }
-        private bool hostReachable = true;
+        private bool HostReachable = true;
 
         public StatsdUDP(string name, int port, int maxUDPPacketSize = MetricsConfig.DefaultStatsdMaxUDPPacketSize)
         {

--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -28,9 +28,9 @@ namespace StatsdClient
             {
                 IPEndpoint = new IPEndPoint(GetIpv4Address(name), Port);
             }
-            catch (SocketException socketException)
+            catch (SocketException)
             {
-               hostReachable = false;            }
+               HostReachable = false;            }
             
         }
 
@@ -89,7 +89,7 @@ namespace StatsdClient
                     // be sent without issue.
                 }
             }
-            if (hostReachable)
+            if (HostReachable)
             {
                 UDPSocket.SendTo(encodedCommand, encodedCommand.Length, SocketFlags.None, IPEndpoint);   
             }

--- a/src/Tests/StatsdUDPTests.cs
+++ b/src/Tests/StatsdUDPTests.cs
@@ -151,5 +151,12 @@ namespace Tests
             AssertWasReceived(String.Format("{0}:1|c", msg), 0);
             AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
         }
+
+        [Test] public void client_does_not_crash_when_ipaddress_is_not_resolved_from_hostname()
+        {
+            var statsdUDP = new StatsdUDP("foobar", serverPort, 10);
+            var statsdClient = new Statsd(statsdUDP);
+        }
+
     }
 }


### PR DESCRIPTION
The client crashes with SocketException when the call to Dns.GetHostEntry fails to resolve the ip address from the host name. The following commits catches the exception and prevents the client from crashing. Please let me know what you think.