### PR TITLE
Minor improvement in the the disposable patterns and creation of a NullStatsd object

### DIFF
--- a/src/StatsdClient/IStatsd.cs
+++ b/src/StatsdClient/IStatsd.cs
@@ -14,7 +14,9 @@ namespace StatsdClient
         void Add<TCommandType>(string name, double value) where TCommandType : IAllowsDouble;
 
         void Send<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate;
-        void Add<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate;  
+        void Add<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate;
+
+        void Send<TCommandType>(string name, string value) where TCommandType : IAllowsString;
                 
         void Send();
         

--- a/src/StatsdClient/NullStatsd.cs
+++ b/src/StatsdClient/NullStatsd.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace StatsdClient
+{
+    public class NullStatsd : IStatsd
+
+
+    {
+        public NullStatsd()
+        {
+            Commands = new List<string>();
+        }
+
+        public List<string> Commands { get; private set; }
+
+        public void Send<TCommandType>(string name, int value) where TCommandType : IAllowsInteger
+        {
+        }
+
+        public void Add<TCommandType>(string name, int value) where TCommandType : IAllowsInteger
+        {
+        }
+
+        public void Send<TCommandType>(string name, double value) where TCommandType : IAllowsDouble
+        {
+        }
+
+        public void Add<TCommandType>(string name, double value) where TCommandType : IAllowsDouble
+        {
+        }
+
+        public void Send<TCommandType>(string name, int value, double sampleRate)
+            where TCommandType : IAllowsInteger, IAllowsSampleRate
+        {
+        }
+
+        public void Add<TCommandType>(string name, int value, double sampleRate)
+            where TCommandType : IAllowsInteger, IAllowsSampleRate
+        {
+        }
+
+        public void Send<TCommandType>(string name, string value) where TCommandType : IAllowsString
+        {
+            
+        }
+
+        public void Send()
+        {
+        }
+
+        public void Add(Action actionToTime, string statName, double sampleRate = 1)
+        {
+            actionToTime();
+        }
+
+        public void Send(Action actionToTime, string statName, double sampleRate = 1)
+        {
+            actionToTime();
+        }
+    }
+}

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Metrics.cs" />
     <Compile Include="MetricsConfig.cs" />
     <Compile Include="MetricsTimer.cs" />
+    <Compile Include="NullStatsd.cs" />
     <Compile Include="RandomGenerator.cs" />
     <Compile Include="Statsd.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -13,6 +13,7 @@ namespace StatsdClient
         private Socket UDPSocket { get; set; }
         private string Name { get; set; }
         private int Port { get; set; }
+        private bool _disposed;
 
         public StatsdUDP(string name, int port, int maxUDPPacketSize = MetricsConfig.DefaultStatsdMaxUDPPacketSize)
         {
@@ -85,9 +86,42 @@ namespace StatsdClient
             UDPSocket.SendTo(encodedCommand, encodedCommand.Length, SocketFlags.None, IPEndpoint);
         }
 
+
+        //reference : https://lostechies.com/chrispatterson/2012/11/29/idisposable-done-right/
         public void Dispose()
         {
-            UDPSocket.Close();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        ~StatsdUDP() 
+        {
+            // Finalizer calls Dispose(false)
+            Dispose(false);
+        }
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                if (UDPSocket != null)
+                {
+                    try
+                    {
+                        UDPSocket.Close();
+                    }
+                    catch (Exception)
+                    {
+                        //Swallow since we are not using a logger, should we add LibLog and start logging??
+                    }
+                    
+                }
+            }
+
+            
+
+            _disposed = true;
         }
     }
 }

--- a/src/Tests/App.config
+++ b/src/Tests/App.config
@@ -2,7 +2,7 @@
 <!-- Local -->
 <configuration>
   <appSettings>
-    <add key="StatsdServerName" value="try_your_host_name_here"/>
+    <add key="StatsdServerName" value="localhost"/>
     <add key="StatsdServerPort" value="8125"/>
 
     <add key="StatsdEnvironment" value="environment"/>


### PR DESCRIPTION
Added a Nullstatsd as a nullobject to avoid comparing with null.
Improved the IDisposable implementation of StatsdUDP.
Changedstatic class Metrics to ensure that if it's reconfigured the old StatsdUDP will be disposed.
Extract the Send(strig,strig) method to the interface IStatsD.

No new tests added since it was a minor refactoring.