### PR TITLE
Fix regression bug when Configure isn't called.

### DIFF
--- a/src/StatsdClient/Metrics.cs
+++ b/src/StatsdClient/Metrics.cs
@@ -4,7 +4,7 @@ namespace StatsdClient
 {
     public static class Metrics
     {
-        private static IStatsd _statsD;
+        private static IStatsd _statsD = new NullStatsd();
         private static StatsdUDP _statsdUdp;
         private static string _prefix;
 
@@ -32,11 +32,7 @@ namespace StatsdClient
             if (!string.IsNullOrEmpty(config.StatsdServerName))
             {
                 _statsdUdp = new StatsdUDP(config.StatsdServerName, config.StatsdServerPort, config.StatsdMaxUDPPacketSize);
-                _statsD=new Statsd(_statsdUdp);
-            }
-            else
-            {
-                _statsD = new NullStatsd();
+                _statsD = new Statsd(_statsdUdp);
             }
         }
 

--- a/src/StatsdClient/Metrics.cs
+++ b/src/StatsdClient/Metrics.cs
@@ -28,7 +28,7 @@ namespace StatsdClient
             }
 
             _statsdUdp = null;
-            
+
             if (!string.IsNullOrEmpty(config.StatsdServerName))
             {
                 _statsdUdp = new StatsdUDP(config.StatsdServerName, config.StatsdServerPort, config.StatsdMaxUDPPacketSize);

--- a/src/StatsdClient/Properties/AssemblyInfo.cs
+++ b/src/StatsdClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.18")]
+[assembly: AssemblyVersion("1.0.0.19")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Tests/A_MetricsTests.cs
+++ b/src/Tests/A_MetricsTests.cs
@@ -1,0 +1,17 @@
+﻿using NUnit.Framework;
+using StatsdClient;
+
+namespace Tests
+{
+	/// <summary>
+	/// Metrics is static (not thread static), so to consistently test this before .Configure() is called just doing a cheeky A_* naming so it's first alphabetically.
+	/// </summary>
+	public class A_MetricsTests
+	{
+		[Test]
+		public void defaults_to_null_statsd_to_not_blow_up_when_configure_is_not_called()
+		{
+			Metrics.Counter("stat");
+		}
+	}
+}

--- a/src/Tests/MetricsTests.cs
+++ b/src/Tests/MetricsTests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StatsdClient;
+
+namespace Tests
+{
+	public class MetricsTests
+	{
+		[Test]
+		public void throws_when_configured_with_a_null_configuration()
+		{
+			Assert.Throws<ArgumentNullException>(() => Metrics.Configure(null));
+		}
+	}
+}

--- a/src/Tests/StatsdClient.Tests.csproj
+++ b/src/Tests/StatsdClient.Tests.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IPV4ParsingTests.cs" />
+    <Compile Include="MetricsTests.cs" />
     <Compile Include="NamingIntegrationTests.cs" />
     <Compile Include="RandomGeneratorUnitTests.cs" />
     <Compile Include="UDPSmokeTests.cs" />

--- a/src/Tests/StatsdClient.Tests.csproj
+++ b/src/Tests/StatsdClient.Tests.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="A_MetricsTests.cs" />
     <Compile Include="IPV4ParsingTests.cs" />
     <Compile Include="MetricsTests.cs" />
     <Compile Include="NamingIntegrationTests.cs" />


### PR DESCRIPTION
Tests will often not call `Metrics.Configure()`, resulting in a null `_statsD` object and null reference exceptions in the various Counter/Timer/etc calls below. Defaulting to a `NullStatsd` instead to revert to the original desireable behaviour.