### PR TITLE
StatsDClient Updates - Thread Safety, Batching, Aggregation

### DIFF
--- a/README-FORK.md
+++ b/README-FORK.md
@@ -1,0 +1,47 @@
+C# Statsd Client - Thread Safe Consumer/Producer Sender
+=======================================================
+
+Kyle West (kwest2123@yahoo.com)
+7/30/2015
+
+
+This fork adds a few features to the statsD client:
+
+- Thread safe
+- Bundles multiple metrics into a UDP packet (up to max packet size) for increased performance.
+- Aggregates metric types that can be aggregated (counters and gauges) and sends the aggregated result rather than sending the same metric multiple times within the same packet
+- Uses the producer/consumer pattern to allow a different number of producer threads vs. sender thread(s)
+
+
+With this fork, an unlimited number of threads can all safely send metrics to the same StatsD client instance.  The client uses a .NET 4 BlockingCollection to add metrics to be sent into a thread safe queue without requiring a lock, so it runs very fast and is thread safe.  A configurable number of consumer worker thread(s) monitor this queue and send metrics to the server.  The default value in the code if not specified is 1 thread, which is probably fine for most applications.
+
+There are two configuration options that control send behavior.
+
+| Configuration Option | Default Value | Description                                                                                                                                                                                                                                                                                                                                      |
+|----------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MaxSendDelayMS       | 5000          | Maximum amount of time (in milliseconds), to wait for additional metrics to be sent before bundling up the metrics and sending them to the server.  It is important that this value is always smaller than the flush interval.                                                                                                                   |
+| MaxThreads           | 1             | Number of worker threads that will be used to send metrics to StatsD.  In very high volume use cases, a single worker thread may not be able to keep up with all of the metrics to be sent.  In that case, the number of threads can be increased with this option.  In most cases, the default value of one worker thread should be sufficient. |
+
+
+To configure these options, create an instance of the ThreadSafeConsumerProducerSender using the appropriate configuration options, and use it as the value for the Sender property in your MetricsConfig object.
+
+``` C#
+var metricsConfig = new MetricsConfig
+{
+  StatsdServerName = "host.name",
+  Prefix = "myApp",
+  Sender = new ThreadSafeConsumerProducerSender(
+    new ThreadSafeConsumerProducerSender.Configuration() { 
+      MaxSendDelayMS = 5000,
+      MaxThreads = 3
+};
+Metrics.Configure(metricsConfig);
+
+// Or, if using the Statsd class directly:
+var sender = new ThreadSafeConsumerProducerSender(
+  new ThreadSafeConsumerProducerSender.Configuration() {
+    MaxSendDelayMS = 5000,
+    MaxThreads = 3
+  });
+var statsd = new Statsd(new Statsd.Configuration() { Udp = ..., Sender = sender });
+```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Via the Statsd class:
 StatsdUDP udp = new StatsdUDP(HOSTNAME, PORT);
 using (udp)
 {
-  Statsd s = new Statsd(udp);
+  Statsd s = new Statsd(new Statsd.Configuration() { Udp = udp });
 
   //All the standard Statsd message types:
   s.Send<Statsd.Counting>("stat-name", 1); //counter had one hit

--- a/README.md
+++ b/README.md
@@ -79,15 +79,7 @@ using (udp)
   
   //All types have sample rate, which will be included in the message for Statsd's own stats crunching:
   s.Send<Statsd.Counting>("stat-name", 1, 1/10); //counter had one hit, this will be sent 10% of times it is called
-
-  //You can add combinations of messages which will be sent in one go:
-  s.Add<Statsd.Counting>("stat-name", 1);
-  s.Add<Statsd.Timer>("stat-name", 5, 1/10);
-  s.Send(); //message will contain counter and will contain timer 10% of the time
-  
-  //All previous commands will be flushed after any Send
-  //Any Adds will be ignored if using a Send directly
-  
+ 
   //Optional naming conventions:
   // environment named 'env'
   // application named 'app'
@@ -100,6 +92,5 @@ using (udp)
 
   s.Send(() => DoMagic(), "stat-name", 1/10); //log the response time for DoMagic call as a timer
   s.Send(() => DoMagic(), "stat-name"); //same with no sample rate
-  s.Add(() => DoMagic(), "stat-name"); //you can just add it too
 }
 ```

--- a/src/StatsdClient/IStatsd.cs
+++ b/src/StatsdClient/IStatsd.cs
@@ -1,3 +1,4 @@
+using StatsdClient.MetricTypes;
 using System;
 using System.Collections.Generic;
 
@@ -5,22 +6,10 @@ namespace StatsdClient
 {
     public interface IStatsd
     {
-        List<string> Commands { get; }
-        
-        void Send<TCommandType>(string name, int value) where TCommandType : IAllowsInteger;
-        void Add<TCommandType>(string name, int value) where TCommandType : IAllowsInteger;
-
-        void Send<TCommandType>(string name, double value) where TCommandType : IAllowsDouble;
-        void Add<TCommandType>(string name, double value) where TCommandType : IAllowsDouble;
-
-        void Send<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate;
-        void Add<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate;
-
-        void Send<TCommandType>(string name, string value) where TCommandType : IAllowsString;
-
-        void Send();
-
-        void Add(Action actionToTime, string statName, double sampleRate=1);
+        void Send<TCommandType>(string name, int value) where TCommandType : Metric, IAllowsInteger, new();
+        void Send<TCommandType>(string name, double value) where TCommandType : Metric, IAllowsDouble, new();
+        void Send<TCommandType>(string name, int value, double sampleRate) where TCommandType : Metric, IAllowsInteger, IAllowsSampleRate, new();
+        void Send<TCommandType>(string name, string value) where TCommandType : Metric, IAllowsString, new();
         void Send(Action actionToTime, string statName, double sampleRate=1);
     }
 }

--- a/src/StatsdClient/IStatsdUDP.cs
+++ b/src/StatsdClient/IStatsdUDP.cs
@@ -2,6 +2,8 @@ namespace StatsdClient
 {
     public interface IStatsdUDP
     {
+        int MaxUDPPacketSize { get; }
+
         void Send(string command);
     }
 }

--- a/src/StatsdClient/MetricTypes/Counting.cs
+++ b/src/StatsdClient/MetricTypes/Counting.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StatsdClient.MetricTypes
+{
+    public class Counting : Metric, IAllowsInteger, IAllowsSampleRate, IAllowsAggregate
+    {
+        public Counting(string name, double sampleRate = 1) : base(name, "c", sampleRate)
+        {
+        }
+
+        public Counting() : this(string.Empty) { }
+
+        public override void Aggregate(Metric otherMetric)
+        {
+            this.ValueAsInt += otherMetric.ValueAsInt;
+        }
+    }
+}

--- a/src/StatsdClient/MetricTypes/Gauge.cs
+++ b/src/StatsdClient/MetricTypes/Gauge.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StatsdClient.MetricTypes
+{
+    public class Gauge : Metric, IAllowsDouble, IAllowsAggregate
+    {
+        public Gauge(string name) : base(name, "g")
+        {
+        }
+
+        public Gauge() : this(string.Empty) { }
+
+        public override void Aggregate(Metric otherMetric)
+        {
+            this.ValueAsDouble = otherMetric.ValueAsDouble;
+        }
+    }
+}

--- a/src/StatsdClient/MetricTypes/Histogram.cs
+++ b/src/StatsdClient/MetricTypes/Histogram.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StatsdClient.MetricTypes
+{
+    public class Histogram : Metric, IAllowsInteger
+    {
+        public Histogram(string name) : base(name, "h")
+        {
+        }
+
+        public Histogram() : this(string.Empty) { }
+
+    }
+}

--- a/src/StatsdClient/MetricTypes/Meter.cs
+++ b/src/StatsdClient/MetricTypes/Meter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StatsdClient.MetricTypes
+{
+    public class Meter : Metric, IAllowsInteger
+    {
+        public Meter(string name) : base(name, "m")
+        {
+        }
+
+        public Meter() : this(string.Empty) { }
+
+    }
+}

--- a/src/StatsdClient/MetricTypes/Metric.cs
+++ b/src/StatsdClient/MetricTypes/Metric.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace StatsdClient.MetricTypes
+{
+    public interface IAllowsSampleRate { }
+    public interface IAllowsDouble { }
+    public interface IAllowsInteger { }
+    public interface IAllowsString { }
+    public interface IAllowsAggregate { }
+
+    public abstract class Metric
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+        public double SampleRate { get; set; }
+        public string UnitType { get; protected set; }
+
+        public Metric(string name, string unitType, double sampleRate = 1)
+        {
+            this.Name = name;
+            this.UnitType = unitType;
+            this.SampleRate = sampleRate;
+        }
+
+        public virtual string Command
+        {
+            get
+            {
+                var format = this.SampleRate == 1 ? "{0}:{1}|{2}" : "{0}:{1}|{2}|@{3}";
+                return string.Format(CultureInfo.InvariantCulture, format, this.Name, this.Value, this.UnitType, this.SampleRate);
+            }
+        }
+
+        public int ValueAsInt
+        {
+            get
+            {
+                int rv = 0;
+                int.TryParse(this.Value, out rv);
+                return rv;
+            }
+            set
+            {
+                this.Value = value.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        public double ValueAsDouble
+        {
+            get
+            {
+                double rv = 0;
+                double.TryParse(this.Value, out rv);
+                return rv;
+            }
+            set
+            {
+                this.Value = String.Format(CultureInfo.InvariantCulture, "{0:F15}", value);
+            }
+        }
+
+        public virtual void Aggregate(Metric otherMetric)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/StatsdClient/MetricTypes/Set.cs
+++ b/src/StatsdClient/MetricTypes/Set.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StatsdClient.MetricTypes
+{
+    public class Set : Metric, IAllowsString
+    {
+        public Set(string name) : base(name, "s")
+        {
+        }
+
+        public Set() : this(string.Empty) { }
+
+    }
+}

--- a/src/StatsdClient/MetricTypes/Timing.cs
+++ b/src/StatsdClient/MetricTypes/Timing.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StatsdClient.MetricTypes
+{
+    public class Timing : Metric, IAllowsInteger, IAllowsSampleRate
+    {
+        public Timing(string name, double sampleRate = 1) : base(name, "ms", sampleRate)
+        {
+        }
+
+        public Timing() : this(string.Empty) { }
+
+    }
+}

--- a/src/StatsdClient/Metrics.cs
+++ b/src/StatsdClient/Metrics.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using StatsdClient.MetricTypes;
+using System;
 
 namespace StatsdClient
 {
@@ -32,23 +33,23 @@ namespace StatsdClient
             if (!string.IsNullOrEmpty(config.StatsdServerName))
             {
                 _statsdUdp = new StatsdUDP(config.StatsdServerName, config.StatsdServerPort, config.StatsdMaxUDPPacketSize);
-                _statsD = new Statsd(_statsdUdp);
+                _statsD = new Statsd(new Statsd.Configuration() { Udp = _statsdUdp, Sender = config.Sender });
             }
         }
 
         public static void Counter(string statName, int value = 1, double sampleRate = 1)
         {
-            _statsD.Send<Statsd.Counting>(BuildNamespacedStatName(statName), value, sampleRate);
+            _statsD.Send<Counting>(BuildNamespacedStatName(statName), value, sampleRate);
         }
 
         public static void Gauge(string statName, double value)
         {
-            _statsD.Send<Statsd.Gauge>(BuildNamespacedStatName(statName), value);
+            _statsD.Send<Gauge>(BuildNamespacedStatName(statName), value);
         }
 
         public static void Timer(string statName, int value, double sampleRate = 1)
         {
-            _statsD.Send<Statsd.Timing>(BuildNamespacedStatName(statName), value, sampleRate);
+            _statsD.Send<Timing>(BuildNamespacedStatName(statName), value, sampleRate);
         }
 
         public static IDisposable StartTimer(string name)
@@ -71,7 +72,7 @@ namespace StatsdClient
 
         public static void Set(string statName, string value)
         {
-            _statsD.Send<Statsd.Set>(BuildNamespacedStatName(statName), value);
+            _statsD.Send<Set>(BuildNamespacedStatName(statName), value);
         }
 
         private static string BuildNamespacedStatName(string statName)

--- a/src/StatsdClient/MetricsConfig.cs
+++ b/src/StatsdClient/MetricsConfig.cs
@@ -1,4 +1,5 @@
-﻿namespace StatsdClient
+﻿using StatsdClient.Senders;
+namespace StatsdClient
 {
     public class MetricsConfig
     {
@@ -23,6 +24,11 @@
         /// </summary>
         public string Prefix { get; set; }
 
+        /// <summary>
+        /// Allows you to configure the Sender that is used to transmit data to StatsD.
+        /// </summary>
+        public ISender Sender { get; set; }
+
         public const int DefaultStatsdServerPort = 8125;
         public const int DefaultStatsdMaxUDPPacketSize = 512;
 
@@ -30,6 +36,7 @@
         {
             StatsdServerPort = DefaultStatsdServerPort;
             StatsdMaxUDPPacketSize = DefaultStatsdMaxUDPPacketSize;
+            Sender = null;
         }
     }
 }

--- a/src/StatsdClient/NullStatsd.cs
+++ b/src/StatsdClient/NullStatsd.cs
@@ -1,54 +1,32 @@
-﻿using System;
+﻿using StatsdClient.MetricTypes;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace StatsdClient
 {
     public class NullStatsd : IStatsd
     {
+
         public NullStatsd()
         {
-            Commands = new List<string>();
         }
 
-        public List<string> Commands { get; private set; }
-
-        public void Send<TCommandType>(string name, int value) where TCommandType : IAllowsInteger
+        public void Send<TCommandType>(string name, int value) where TCommandType : Metric, IAllowsInteger, new()
         {
         }
 
-        public void Add<TCommandType>(string name, int value) where TCommandType : IAllowsInteger
+        public void Send<TCommandType>(string name, double value) where TCommandType : Metric, IAllowsDouble, new()
         {
         }
 
-        public void Send<TCommandType>(string name, double value) where TCommandType : IAllowsDouble
+        public void Send<TCommandType>(string name, string value) where TCommandType : Metric, IAllowsString, new()
         {
         }
 
-        public void Add<TCommandType>(string name, double value) where TCommandType : IAllowsDouble
+        public void Send<TCommandType>(string name, int value, double sampleRate) where TCommandType : Metric, IAllowsInteger, IAllowsSampleRate, new()
         {
-        }
-
-        public void Send<TCommandType>(string name, int value, double sampleRate)
-            where TCommandType : IAllowsInteger, IAllowsSampleRate
-        {
-        }
-
-        public void Add<TCommandType>(string name, int value, double sampleRate)
-            where TCommandType : IAllowsInteger, IAllowsSampleRate
-        {
-        }
-
-        public void Send<TCommandType>(string name, string value) where TCommandType : IAllowsString
-        {
-        }
-
-        public void Send()
-        {
-        }
-
-        public void Add(Action actionToTime, string statName, double sampleRate = 1)
-        {
-            actionToTime();
         }
 
         public void Send(Action actionToTime, string statName, double sampleRate = 1)

--- a/src/StatsdClient/Senders/BatchSender.cs
+++ b/src/StatsdClient/Senders/BatchSender.cs
@@ -1,0 +1,57 @@
+﻿using StatsdClient.MetricTypes;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace StatsdClient.Senders
+{
+    // Primarily here for unit testing of the StatsdUDP class.
+    // Will not send out messages until Flush() is called.
+
+    public class BatchSender : ISender
+    {
+        public IStatsdUDP StatsdUDP { get; set; }
+        
+        private List<Metric> _metrics = new List<Metric>();
+
+        public BatchSender()
+        {
+        }
+
+        public void Send(Metric metric)
+        {
+            if(metric != null)
+            {
+                lock (_metrics)
+                    _metrics.Add(metric);
+            }
+        }
+
+        public void Flush()
+        {
+            try
+            { 
+                string[] allCommands;
+                lock(_metrics)
+                {
+                    allCommands = _metrics.Select(x => x.Command).ToArray();
+                    _metrics.Clear();
+                }
+
+                if (allCommands != null && allCommands.Length != 0 && StatsdUDP != null)
+                {
+                    var data = string.Join("\n", allCommands);
+                    StatsdUDP.Send(data);
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Trace.TraceError("StatsdClient::BatchSender - Error: {0}", ex.ToString());
+            }
+        }
+    }
+}

--- a/src/StatsdClient/Senders/ISender.cs
+++ b/src/StatsdClient/Senders/ISender.cs
@@ -8,6 +8,7 @@ namespace StatsdClient.Senders
 {
     public interface ISender
     {
+        IStatsdUDP StatsdUDP { get; set; }
         void Send(Metric metric);
     }
 }

--- a/src/StatsdClient/Senders/ISender.cs
+++ b/src/StatsdClient/Senders/ISender.cs
@@ -1,0 +1,13 @@
+﻿using StatsdClient.MetricTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StatsdClient.Senders
+{
+    public interface ISender
+    {
+        void Send(Metric metric);
+    }
+}

--- a/src/StatsdClient/Senders/ImmediateSender.cs
+++ b/src/StatsdClient/Senders/ImmediateSender.cs
@@ -11,11 +11,10 @@ namespace StatsdClient.Senders
 {
     public class ImmediateSender : ISender
     {
-        private readonly Configuration _config = null;
+        public IStatsdUDP StatsdUDP { get; set; }
 
-        public ImmediateSender(Configuration config)
+        public ImmediateSender()
         {
-            _config = config;
         }
 
         public void Send(Metric metric)
@@ -23,21 +22,12 @@ namespace StatsdClient.Senders
             try
             {
                 var data = string.Join("\n", metric.Command);
-                _config.StatsdUDP.Send(data);
+                if(StatsdUDP != null)
+                    StatsdUDP.Send(data);
             }
             catch(System.Exception ex)
             {
                 Trace.TraceError("StatsdClient::ImmediateSender - Error: {0}", ex.ToString());
-            }
-        }
-
-        public class Configuration
-        {
-            public IStatsdUDP StatsdUDP { get; set; }
-
-            public Configuration()
-            {
-                this.StatsdUDP = null;
             }
         }
     }

--- a/src/StatsdClient/Senders/ImmediateSender.cs
+++ b/src/StatsdClient/Senders/ImmediateSender.cs
@@ -1,0 +1,44 @@
+﻿using StatsdClient.MetricTypes;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace StatsdClient.Senders
+{
+    public class ImmediateSender : ISender
+    {
+        private readonly Configuration _config = null;
+
+        public ImmediateSender(Configuration config)
+        {
+            _config = config;
+        }
+
+        public void Send(Metric metric)
+        {
+            try
+            {
+                var data = string.Join("\n", metric.Command);
+                _config.StatsdUDP.Send(data);
+            }
+            catch(System.Exception ex)
+            {
+                Trace.TraceError("StatsdClient::ImmediateSender - Error: {0}", ex.ToString());
+            }
+        }
+
+        public class Configuration
+        {
+            public IStatsdUDP StatsdUDP { get; set; }
+
+            public Configuration()
+            {
+                this.StatsdUDP = null;
+            }
+        }
+    }
+}

--- a/src/StatsdClient/Senders/MockSender.cs
+++ b/src/StatsdClient/Senders/MockSender.cs
@@ -11,16 +11,11 @@ namespace StatsdClient.Senders
 {
     public class MockSender : ISender
     {
-        private readonly Configuration _config = null;
+        // Not used
+        public IStatsdUDP StatsdUDP { get; set; }
 
-        public MockSender() : this(null)
+        public MockSender() 
         {
-
-        }
-
-        public MockSender(Configuration config)
-        {
-            _config = config;
         }
 
         public void Send(Metric metric)
@@ -33,13 +28,6 @@ namespace StatsdClient.Senders
             catch(System.Exception ex)
             {
                 Trace.TraceError("StatsdClient::MockSender - Error: {0}", ex.ToString());
-            }
-        }
-
-        public class Configuration
-        {
-            public Configuration()
-            {
             }
         }
     }

--- a/src/StatsdClient/Senders/MockSender.cs
+++ b/src/StatsdClient/Senders/MockSender.cs
@@ -1,0 +1,46 @@
+﻿using StatsdClient.MetricTypes;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace StatsdClient.Senders
+{
+    public class MockSender : ISender
+    {
+        private readonly Configuration _config = null;
+
+        public MockSender() : this(null)
+        {
+
+        }
+
+        public MockSender(Configuration config)
+        {
+            _config = config;
+        }
+
+        public void Send(Metric metric)
+        {
+            try
+            {
+                var data = string.Join("\n", metric.Command);
+                Debug.WriteLine(string.Format("MockSender::{0}", data));
+            }
+            catch(System.Exception ex)
+            {
+                Trace.TraceError("StatsdClient::MockSender - Error: {0}", ex.ToString());
+            }
+        }
+
+        public class Configuration
+        {
+            public Configuration()
+            {
+            }
+        }
+    }
+}

--- a/src/StatsdClient/Senders/ThreadSafeConsumerProducerSender.cs
+++ b/src/StatsdClient/Senders/ThreadSafeConsumerProducerSender.cs
@@ -1,0 +1,170 @@
+﻿using StatsdClient.MetricTypes;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace StatsdClient.Senders
+{
+    public class ThreadSafeConsumerProducerSender : ISender, IDisposable
+    {
+        private BlockingCollection<Metric> _queue = new BlockingCollection<Metric>();
+        private CancellationTokenSource _cancelSource = null;
+        private List<Thread> _sendWorkerThreads = new List<Thread>();
+
+        private readonly Configuration _config = null;
+
+        public ThreadSafeConsumerProducerSender(Configuration config)
+        {
+            _config = config;
+            Start();
+        }
+
+        private void Start()
+        {
+            _cancelSource = new CancellationTokenSource();
+            for (var i = 0; i < _config.MaxThreads; i++)
+            {
+                var thread = new Thread(RunWorkerThread);
+                thread.IsBackground = true;
+                _sendWorkerThreads.Add(thread);
+                thread.Start();
+            }
+        }
+
+        private void Stop()
+        {
+            _cancelSource.Cancel();
+            for (var i = 0; i < _sendWorkerThreads.Count; i++)
+            {
+                _sendWorkerThreads[i].Join(1000);
+                _sendWorkerThreads[i] = null;
+            }
+            _sendWorkerThreads.Clear();
+            _cancelSource = null;
+        }
+
+        public void Send(Metric metric)
+        {
+            _queue.TryAdd(metric);
+        }
+
+        private void RunWorkerThread()
+        {
+            try
+            {
+                Metric carryoverMetric = null;
+                var maxPacketSize = _config.StatsdUDP.MaxUDPPacketSize;
+
+                while (true)
+                {
+                    if (_cancelSource.IsCancellationRequested)
+                        return;
+
+                    List<Metric> metric = new List<Metric>();
+                    List<string> metricsAsString = new List<string>();
+                    Dictionary<string, int> mapNameToIndex = new Dictionary<string, int>();
+
+                    int totLen = 0;
+                    Metric firstMetric = null;
+
+                    if (carryoverMetric != null)
+                    {
+                        firstMetric = carryoverMetric;
+                        carryoverMetric = null;
+                    }
+                    else
+                        firstMetric = _queue.Take(_cancelSource.Token);
+
+                    if (firstMetric != null)
+                    {
+                        metric.Add(firstMetric);
+                        var cmd = firstMetric.Command;
+                        metricsAsString.Add(cmd);
+                        totLen += cmd.Length;
+
+                        if (firstMetric is IAllowsAggregate)
+                            mapNameToIndex.Add(firstMetric.Name, metric.Count - 1);
+                    }
+
+                    Metric nextMetric = null;
+                    DateTime delayStart = DateTime.UtcNow;
+                    DateTime delayEnd = DateTime.UtcNow.AddMilliseconds(_config.MaxSendDelayMS);
+                    int msRemaining;
+                    while ((maxPacketSize <= 0 || totLen < maxPacketSize) && ((msRemaining = (int)(delayEnd - DateTime.UtcNow).TotalMilliseconds) > 0) && _queue.TryTake(out nextMetric, msRemaining, _cancelSource.Token))
+                    {
+                        if (nextMetric != null)
+                        {
+                            var canAggregate = nextMetric is IAllowsAggregate;
+                            if (canAggregate && mapNameToIndex.ContainsKey(nextMetric.Name))
+                            {
+                                var existingItemIndex = mapNameToIndex[nextMetric.Name];
+                                metric[existingItemIndex].Aggregate(nextMetric);
+
+                                var oldStr = metricsAsString[existingItemIndex];
+                                metricsAsString[existingItemIndex] = metric[existingItemIndex].Command;
+                                totLen += (metricsAsString[existingItemIndex].Length - oldStr.Length);
+                            }
+                            else
+                            {
+                                var cmd = nextMetric.Command;
+                                totLen += (cmd.Length + 1); // +1 for the \n separating each item
+                                if (maxPacketSize <= 0 || totLen < maxPacketSize)
+                                {
+                                    metric.Add(nextMetric);
+                                    metricsAsString.Add(cmd);
+                                    if (canAggregate)
+                                        mapNameToIndex.Add(nextMetric.Name, metric.Count - 1);
+                                }
+                                else
+                                {
+                                    carryoverMetric = nextMetric;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    if (metric.Count != 0)
+                    {
+                        var data = string.Join("\n", metricsAsString.ToArray());
+                        _config.StatsdUDP.Send(data);
+                    }
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Trace.TraceError("StatsdClient::ThreadSafeConsumerProducerSender - Error: {0}", ex.ToString());
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+                Stop();
+        }
+
+        public class Configuration
+        {
+            public IStatsdUDP StatsdUDP { get; set; }
+            public int MaxSendDelayMS { get; set; }
+            public int MaxThreads { get; set; }
+
+            public Configuration()
+            {
+                this.StatsdUDP = null;
+                this.MaxSendDelayMS = 5000;
+                this.MaxThreads = 1;
+            }
+        }
+    }
+}

--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -17,7 +17,9 @@ namespace StatsdClient
                 throw new ArgumentNullException("Configuration.Udp");
 
             if (config.Sender == null)
-                config.Sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = config.Udp });
+                config.Sender = new ThreadSafeConsumerProducerSender();
+            config.Sender.StatsdUDP = config.Udp;
+
             if(config.RandomGenerator == null)
                 config.RandomGenerator = new RandomGenerator();
             if(config.StopwatchFactory == null)

--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -1,3 +1,5 @@
+using StatsdClient.MetricTypes;
+using StatsdClient.Senders;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -5,133 +7,54 @@ using System.Globalization;
 
 namespace StatsdClient
 {
-    public interface IAllowsSampleRate { }
-
-    public interface IAllowsDouble { }
-    public interface IAllowsInteger { }
-    public interface IAllowsString { }
-
     public class Statsd : IStatsd
     {
-        private readonly object _commandCollectionLock = new object();
+        private readonly Configuration _config = null;
 
-        private IStopWatchFactory StopwatchFactory { get; set; }
-        private IStatsdUDP Udp { get; set; }
-        private IRandomGenerator RandomGenerator { get; set; }
-
-        private readonly string _prefix;
-
-        public List<string> Commands { get; private set; }
-
-        public class Counting : IAllowsSampleRate, IAllowsInteger { }
-        public class Timing : IAllowsSampleRate, IAllowsInteger { }
-        public class Gauge : IAllowsDouble { }
-        public class Histogram : IAllowsInteger { }
-        public class Meter : IAllowsInteger { }
-        public class Set : IAllowsString { }
-
-        private readonly Dictionary<Type, string> _commandToUnit = new Dictionary<Type, string>
-                                                                       {
-                                                                           {typeof (Counting), "c"},
-                                                                           {typeof (Timing), "ms"},
-                                                                           {typeof (Gauge), "g"},
-                                                                           {typeof (Histogram), "h"},
-                                                                           {typeof (Meter), "m"},
-                                                                           {typeof (Set), "s"}
-                                                                       };
-
-        public Statsd(IStatsdUDP udp, IRandomGenerator randomGenerator, IStopWatchFactory stopwatchFactory, string prefix)
+        public Statsd(Configuration config)
         {
-            Commands = new List<string>();
-            StopwatchFactory = stopwatchFactory;
-            Udp = udp;
-            RandomGenerator = randomGenerator;
-            _prefix = prefix;
+            if (config.Udp == null)
+                throw new ArgumentNullException("Configuration.Udp");
+
+            if (config.Sender == null)
+                config.Sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = config.Udp });
+            if(config.RandomGenerator == null)
+                config.RandomGenerator = new RandomGenerator();
+            if(config.StopwatchFactory == null)
+                config.StopwatchFactory = new StopWatchFactory();
+            if (config.Prefix == null)
+                config.Prefix = string.Empty;
+            else
+                config.Prefix = config.Prefix.TrimEnd('.');
+            _config = config;
+        }
+        
+        public void Send<TCommandType>(string name, int value) where TCommandType : Metric, IAllowsInteger, new()
+        {
+            _config.Sender.Send(new TCommandType() { Name = BuildNamespacedStatName(name), ValueAsInt = value });
         }
 
-        public Statsd(IStatsdUDP udp, IRandomGenerator randomGenerator, IStopWatchFactory stopwatchFactory)
-            : this(udp, randomGenerator, stopwatchFactory, string.Empty) { }
-
-        public Statsd(IStatsdUDP udp, string prefix)
-            : this(udp, new RandomGenerator(), new StopWatchFactory(), prefix) { }
-
-        public Statsd(IStatsdUDP udp)
-            : this(udp, "") { }
-
-
-        public void Send<TCommandType>(string name, int value) where TCommandType : IAllowsInteger
+        public void Send<TCommandType>(string name, double value) where TCommandType : Metric, IAllowsDouble, new()
         {
-            Commands = new List<string> { GetCommand(name, value.ToString(CultureInfo.InvariantCulture), _commandToUnit[typeof(TCommandType)], 1) };
-            Send();
-        }
-        public void Send<TCommandType>(string name, double value) where TCommandType : IAllowsDouble
-        {
-            Commands = new List<string> { GetCommand(name, String.Format(CultureInfo.InvariantCulture,"{0:F15}", value), _commandToUnit[typeof(TCommandType)], 1) };
-            Send();
-        }
-        public void Send<TCommandType>(string name, string value) where TCommandType : IAllowsString
-        {
-            Commands = new List<string> { GetCommand(name, value.ToString(CultureInfo.InvariantCulture), _commandToUnit[typeof(TCommandType)], 1) };
-            Send();
+            _config.Sender.Send(new TCommandType() { Name = BuildNamespacedStatName(name), ValueAsDouble = value });
         }
 
-        public void Add<TCommandType>(string name, int value) where TCommandType : IAllowsInteger
+        public void Send<TCommandType>(string name, string value) where TCommandType : Metric, IAllowsString, new()
         {
-            ThreadSafeAddCommand(GetCommand(name, value.ToString(CultureInfo.InvariantCulture), _commandToUnit[typeof (TCommandType)], 1));
+            _config.Sender.Send(new TCommandType() { Name = BuildNamespacedStatName(name), Value = value });
         }
 
-        public void Add<TCommandType>(string name, double value) where TCommandType : IAllowsDouble
+        public void Send<TCommandType>(string name, int value, double sampleRate) where TCommandType : Metric, IAllowsInteger, IAllowsSampleRate, new()
         {
-            ThreadSafeAddCommand(GetCommand(name, String.Format(CultureInfo.InvariantCulture,"{0:F15}", value), _commandToUnit[typeof(TCommandType)], 1));
-        }
-
-        public void Send<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate
-        {
-            if (RandomGenerator.ShouldSend(sampleRate))
+            if (_config.RandomGenerator.ShouldSend(sampleRate))
             {
-                Commands = new List<string> { GetCommand(name, value.ToString(CultureInfo.InvariantCulture), _commandToUnit[typeof(TCommandType)], sampleRate) };
-                Send();
+                _config.Sender.Send(new TCommandType() { Name = BuildNamespacedStatName(name), ValueAsInt = value, SampleRate = sampleRate });
             }
         }
 
-        public void Add<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate
+        public void Send(Action actionToTime, string statName, double sampleRate = 1)
         {
-            if (RandomGenerator.ShouldSend(sampleRate))
-            {
-                Commands.Add(GetCommand(name, value.ToString(CultureInfo.InvariantCulture), _commandToUnit[typeof(TCommandType)], sampleRate));
-            }
-        }
-
-        private void ThreadSafeAddCommand(string command)
-        {
-            lock (_commandCollectionLock)
-            {
-                Commands.Add(command);
-            }
-        }
-
-        public void Send()
-        {
-            try
-            {
-                Udp.Send(string.Join("\n", Commands.ToArray()));
-                Commands = new List<string>();
-            }
-            catch(Exception e)
-            {
-                Debug.WriteLine(e.Message);
-            }
-        }
-
-        private string GetCommand(string name, string value, string unit, double sampleRate)
-        {
-            var format = sampleRate == 1 ? "{0}:{1}|{2}" : "{0}:{1}|{2}|@{3}";
-            return string.Format(CultureInfo.InvariantCulture, format, _prefix + name, value, unit, sampleRate);
-        }
-
-        public void Add(Action actionToTime, string statName, double sampleRate=1)
-        {
-            var stopwatch = StopwatchFactory.Get();
+            var stopwatch = _config.StopwatchFactory.Get();
 
             try
             {
@@ -141,30 +64,35 @@ namespace StatsdClient
             finally
             {
                 stopwatch.Stop();
-                if (RandomGenerator.ShouldSend(sampleRate))
-                {
-                    Add<Timing>(statName, stopwatch.ElapsedMilliseconds());
-                }
-            }
-        }
-
-        public void Send(Action actionToTime, string statName, double sampleRate=1)
-        {
-            var stopwatch = StopwatchFactory.Get();
-
-            try
-            {
-                stopwatch.Start();
-                actionToTime();
-            }
-            finally
-            {
-                stopwatch.Stop();
-                if (RandomGenerator.ShouldSend(sampleRate))
+                if (_config.RandomGenerator.ShouldSend(sampleRate))
                 {
                     Send<Timing>(statName, stopwatch.ElapsedMilliseconds());
                 }
             }
         }
+
+        private string BuildNamespacedStatName(string statName)
+        {
+            return ((string.IsNullOrEmpty(_config.Prefix)) ? statName : String.Concat(_config.Prefix, ".", statName));
+        }
+
+        public class Configuration
+        {
+            public IStopWatchFactory StopwatchFactory { get; set; }
+            public IStatsdUDP Udp { get; set; }
+            public IRandomGenerator RandomGenerator { get; set; }
+            public ISender Sender { get; set; }
+            public string Prefix { get; set; }
+        }
+
+        #region Backward Compatibility
+        public class Counting : MetricTypes.Counting { }
+        public class Gauge : MetricTypes.Gauge { }
+        public class Histogram : MetricTypes.Histogram { }
+        public class Meter : MetricTypes.Meter { }
+        public class Set : MetricTypes.Set { }
+        public class Timing : MetricTypes.Timing { }
+        #endregion
+
     }
 }

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -53,6 +53,7 @@
     <Compile Include="MetricTypes\Counting.cs" />
     <Compile Include="NullStatsd.cs" />
     <Compile Include="RandomGenerator.cs" />
+    <Compile Include="Senders\BatchSender.cs" />
     <Compile Include="Senders\MockSender.cs" />
     <Compile Include="Senders\ISender.cs" />
     <Compile Include="Senders\ImmediateSender.cs" />

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StatsdClient</RootNamespace>
     <AssemblyName>StatsdClient</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -36,6 +36,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MetricTypes\Metric.cs" />
     <Compile Include="IRandomGenerator.cs" />
     <Compile Include="IStatsd.cs" />
     <Compile Include="IStatsdUDP.cs" />
@@ -44,8 +45,18 @@
     <Compile Include="Metrics.cs" />
     <Compile Include="MetricsConfig.cs" />
     <Compile Include="MetricsTimer.cs" />
+    <Compile Include="MetricTypes\Gauge.cs" />
+    <Compile Include="MetricTypes\Set.cs" />
+    <Compile Include="MetricTypes\Meter.cs" />
+    <Compile Include="MetricTypes\Histogram.cs" />
+    <Compile Include="MetricTypes\Timing.cs" />
+    <Compile Include="MetricTypes\Counting.cs" />
     <Compile Include="NullStatsd.cs" />
     <Compile Include="RandomGenerator.cs" />
+    <Compile Include="Senders\MockSender.cs" />
+    <Compile Include="Senders\ISender.cs" />
+    <Compile Include="Senders\ImmediateSender.cs" />
+    <Compile Include="Senders\ThreadSafeConsumerProducerSender.cs" />
     <Compile Include="Statsd.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StatsdUDP.cs" />

--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -7,8 +7,8 @@ namespace StatsdClient
 {
     public class StatsdUDP : IDisposable, IStatsdUDP
     {
-        private int MaxUDPPacketSize { get; set; } // In bytes; default is MetricsConfig.DefaultStatsdMaxUDPPacketSize.
-                                                   // Set to zero for no limit.
+        public int MaxUDPPacketSize { get; private set; } // In bytes; default is MetricsConfig.DefaultStatsdMaxUDPPacketSize.
+                                                          // Set to zero for no limit.
         public IPEndPoint IPEndpoint { get; private set; }
         private Socket UDPSocket { get; set; }
         private string Name { get; set; }

--- a/src/Tests/MetricIntegrationTests.cs
+++ b/src/Tests/MetricIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using NUnit.Framework;
 using StatsdClient;
 using Tests.Helpers;
+using StatsdClient.Senders;
 
 namespace Tests
 {
@@ -35,7 +36,8 @@ namespace Tests
             _defaultMetricsConfig = new MetricsConfig
             {
                 StatsdServerName = _localhostAddress,
-                StatsdServerPort = _randomUnusedLocalPort
+                StatsdServerPort = _randomUnusedLocalPort,
+                Sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 100 })
             };
 
             _listenThread = new Thread(_udpListener.Listen);

--- a/src/Tests/StatsdClient.Tests.csproj
+++ b/src/Tests/StatsdClient.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="MetricsTests.cs" />
     <Compile Include="NamingIntegrationTests.cs" />
     <Compile Include="RandomGeneratorUnitTests.cs" />
+    <Compile Include="StatsdSenderTests.cs" />
     <Compile Include="UDPSmokeTests.cs" />
     <Compile Include="StatsdTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Tests/StatsdSenderTests.cs
+++ b/src/Tests/StatsdSenderTests.cs
@@ -102,6 +102,81 @@ namespace Tests
             }
         }
 
+        public class BatchSenderTests : StatsdSenderTests
+        {
+            [Test]
+            public void does_not_blow_up_if_metric_command_throws()
+            {
+                var metric = MockRepository.GenerateStub<Counting>();
+                metric.Stub(x => x.Command).Throw(new Exception());
+
+                var sender = new BatchSender();
+                sender.StatsdUDP = _udp;
+                sender.Send(metric);
+                sender.Flush();
+                Assert.Pass();
+            }
+
+            [Test]
+            public void does_not_blow_up_if_udp_send_throws()
+            {
+                var udpStub = MockRepository.GenerateStub<IStatsdUDP>();
+                udpStub.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 1 };
+                var sender = new BatchSender    ();
+                sender.StatsdUDP = udpStub;
+                sender.Send(metric);
+                sender.Flush();
+                Assert.Pass();
+            }
+
+            [Test]
+            public void does_not_send_metric_immediately()
+            {
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 5 };
+                var sender = new BatchSender();
+                sender.StatsdUDP = _udp;
+                sender.Send(metric);
+
+                _udp.AssertWasNotCalled(x => x.Send(Arg<string>.Is.Anything));
+            }
+
+            [Test]
+            public void sends_metric_on_flush()
+            {
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 5 };
+                var sender = new BatchSender();
+                sender.StatsdUDP = _udp;
+                sender.Send(metric);
+                sender.Flush();
+
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((string)argsPerCall[0][0]), Is.EqualTo(metric.Command));
+            }
+
+            [Test]
+            public void sends_multiple_metrics_at_once()
+            {
+                var metric1 = new Counting() { Name = "testMetric", ValueAsInt = 5 };
+                var metric2 = new Timing() { Name = "testtimer", ValueAsInt = 10 };
+
+                var sender = new BatchSender();
+                sender.StatsdUDP = _udp;
+                sender.Send(metric1);
+                sender.Send(metric2);
+                sender.Flush();
+
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                var packet = (string)argsPerCall[0][0];
+                var lines = packet.Split('\n');
+                Assert.That(lines.Length, Is.EqualTo(2));
+                Assert.That(lines[0], Is.EqualTo(metric1.Command));
+                Assert.That(lines[1], Is.EqualTo(metric2.Command));
+            }
+        }
+
         public class ThreadSafeConsumerProducerSenderTests : StatsdSenderTests
         {
             [Test]
@@ -287,358 +362,5 @@ namespace Tests
                 Assert.That(argsPerCall.Count, Is.EqualTo(0));
             }
         }
-
-/*
-        [Test]
-        public void increases_counter_with_value_of_X_and_sample_rate()
-        {
-            var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-            s.Send<Counting>("counter", 5, 0.1);
-
-            IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-            Assert.That(argsPerCall.Count, Is.EqualTo(1));
-            Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("counter:5|c|@0.1"));
-        }
-
-        [Test]
-        public void counting_exception_fails_silently()
-        {
-            var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-            _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
-            s.Send<Counting>("counter", 5);
-            Assert.Pass();
-        }
-
-        public class Timer : StatsdTests
-        {
-            [Test]
-            public void sends_timing()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<Timing>("timer", 5);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("timer:5|ms"));
-            }
-
-            [Test]
-            public void timing_with_value_of_X_and_sample_rate()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<Timing>("timer", 5, 0.1);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("timer:5|ms|@0.1"));
-            }
-
-            [Test]
-            public void timing_exception_fails_silently()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
-                s.Send<Timing>("timer", 5);
-                Assert.Pass();
-            }
-
-            [Test]
-            public void send_timer_with_lamba()
-            {
-                const string statName = "name";
-
-                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
-                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
-                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
-
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send(() => TestMethod(), statName);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
-            }
-
-            [Test]
-            public void send_timer_with_lamba_and_sampleRate_passes()
-            {
-                const string statName = "name";
-
-                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
-                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
-                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
-                _randomGenerator = MockRepository.GenerateMock<IRandomGenerator>();
-                _randomGenerator.Stub(x => x.ShouldSend(Arg<double>.Is.Anything)).Return(true);
-
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send(() => TestMethod(), statName, 0.1);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
-            }
-
-            [Test]
-            public void send_timer_with_lamba_and_sampleRate_fails()
-            {
-                const string statName = "name";
-
-                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
-                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
-                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
-                _randomGenerator = MockRepository.GenerateMock<IRandomGenerator>();
-                _randomGenerator.Stub(x => x.ShouldSend(Arg<double>.Is.Anything)).Return(false);
-
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send(() => TestMethod(), statName, 0.1);
-
-                _sender.AssertWasNotCalled(x => x.Send(Arg<Metric>.Is.Anything));
-            }
-
-            [Test]
-            public void send_timer_with_lamba_still_records_on_error_and_still_bubbles_up_exception()
-            {
-                const string statName = "name";
-
-                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
-                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
-                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
-
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-
-                Assert.Throws<InvalidOperationException>(() => s.Send(() => { throw new InvalidOperationException(); }, statName));
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
-            }
-
-            [Test]
-            public void send_timer_with_lambda()
-            {
-                const string statName = "name";
-                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
-                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
-                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
-
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send(() => TestMethod(), statName);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
-            }
-
-            [Test]
-            public void send_timer_with_lambda_and_sampleRate_passes()
-            {
-                const string statName = "name";
-                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
-                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
-                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
-                _randomGenerator = MockRepository.GenerateMock<IRandomGenerator>();
-                _randomGenerator.Stub(x => x.ShouldSend(Arg<double>.Is.Anything)).Return(true);
-
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send(() => TestMethod(), statName, 0.1);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
-            }
-
-            [Test]
-            public void send_timer_with_lambda_and_sampleRate_fails()
-            {
-                const string statName = "name";
-                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
-                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
-                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
-                _randomGenerator = MockRepository.GenerateMock<IRandomGenerator>();
-                _randomGenerator.Stub(x => x.ShouldSend(Arg<double>.Is.Anything)).Return(false);
-
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send(() => TestMethod(), statName, 0.1);
-
-                _sender.AssertWasNotCalled(x => x.Send(Arg<Metric>.Is.Anything));
-            }
-
-            [Test]
-            public void set_return_value_with_send_timer_with_lambda()
-            {
-                const string statName = "name";
-                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
-                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
-                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
-
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                var returnValue = 0;
-                s.Send(() => returnValue = TestMethod(), statName);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
-                Assert.That(returnValue, Is.EqualTo(5));
-            }
-        }
-
-        public class Guage : StatsdTests
-        {
-            [Test]
-            public void send_gauge_with_large_double_values()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<Gauge>("gauge", 34563478564785);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("gauge:34563478564785.000000000000000|g"));
-            }
-
-            [Test]
-            public void gauge_exception_fails_silently()
-            {
-                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<Gauge>("gauge", 5.0);
-                Assert.Pass();
-            }
-        }
-
-        public class Meter : StatsdTests
-        {
-            [Test]
-            public void send_meter()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<StatsdClient.MetricTypes.Meter>("meter", 5);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("meter:5|m"));
-            }
-
-            [Test]
-            public void meter_exception_fails_silently()
-            {
-                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-
-                s.Send<StatsdClient.MetricTypes.Meter>("meter", 5);
-                Assert.Pass();
-            }
-        }
-
-        public class Histogram : StatsdTests
-        {
-            [Test]
-            public void sends_histogram()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<StatsdClient.MetricTypes.Histogram>("histogram", 5);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("histogram:5|h"));
-            }
-
-            [Test]
-            public void histogram_exception_fails_silently()
-            {
-                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<StatsdClient.MetricTypes.Histogram>("histogram", 5);
-                Assert.Pass();
-            }
-        }
-
-        public class Set : StatsdTests
-        {
-            [Test]
-            public void sets_set_with_string_value()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<StatsdClient.MetricTypes.Set>("set", "34563478564785xyz");
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("set:34563478564785xyz|s"));
-            }
-
-            [Test]
-            public void set_exception_fails_silently()
-            {
-                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<StatsdClient.MetricTypes.Set>("set", "silent-exception-test");
-                Assert.Pass();
-            }
-        }
-
-        public class Combination : StatsdTests
-        {
-            [Test]
-            public void send_one_counter_and_one_timer_shows_in_commands()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<Counting>("counter", 1, 0.1);
-                s.Send<Timing>("timer", 1);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(2));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("counter:1|c|@0.1"));
-                Assert.That(((Metric)argsPerCall[1][0]).Command, Is.EqualTo("timer:1|ms"));
-            }
-
-            [Test]
-            public void send_one_counter_and_one_timer_with_no_sample_rate_shows_in_commands()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                s.Send<Counting>("counter", 1);
-                s.Send<Timing>("timer", 1);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(2));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("counter:1|c"));
-                Assert.That(((Metric)argsPerCall[1][0]).Command, Is.EqualTo("timer:1|ms"));
-            }
-        }
-
-        public class NamePrefixing : StatsdTests
-        {
-            [Test]
-            public void set_prefix_on_stats_name_when_calling_send()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender, Prefix = "a.prefix." });
-                s.Send<Counting>("counter", 5);
-
-                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
-                Assert.That(argsPerCall.Count, Is.EqualTo(1));
-                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("a.prefix.counter:5|c"));
-            }
-        }
-
-        public class Concurrency : StatsdTests
-        {
-            [Test]
-            public void can_concurrently_send_integer_metrics()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                Parallel.For(0, 50000, x => Assert.DoesNotThrow(() => s.Send<Counting>("name", 5)));
-            }
-
-            [Test]
-            public void can_concurrently_send_double_metrics()
-            {
-                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
-                Parallel.For(0, 50000, x => Assert.DoesNotThrow(() => s.Send<Gauge>("name", 5d)));
-            }
-        }
-
-        private static int TestMethod()
-        {
-            return 5;
-        }
- */ 
     }
 }

--- a/src/Tests/StatsdSenderTests.cs
+++ b/src/Tests/StatsdSenderTests.cs
@@ -1,0 +1,630 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rhino.Mocks;
+using StatsdClient;
+using StatsdClient.Senders;
+using StatsdClient.MetricTypes;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Tests
+{
+    [TestFixture]
+    public class StatsdSenderTests
+    {
+        private IStatsdUDP _udp;
+
+        [SetUp]
+        public void Setup()
+        {
+            _udp = MockRepository.GenerateMock<IStatsdUDP>();
+        }
+
+        public class MockSenderTests : StatsdSenderTests
+        {
+            [Test]
+            public void does_not_send_anything()
+            {
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 5 };
+                var sender = new MockSender();
+                sender.Send(metric);
+
+                _udp.AssertWasNotCalled(x => x.Send(Arg<string>.Is.Anything));
+            }
+
+            [Test]
+            public void does_not_blow_up_if_metric_command_throws()
+            {
+                var metric = MockRepository.GenerateStub<Counting>();
+                metric.Stub(x => x.Command).Throw(new Exception());
+
+                var sender = new MockSender();
+                sender.Send(metric);
+                Assert.Pass();
+            }
+        }
+
+        public class ImmediateSenderTests : StatsdSenderTests
+        {
+            [Test]
+            public void does_not_blow_up_if_metric_command_throws()
+            {
+                var metric = MockRepository.GenerateStub<Counting>();
+                metric.Stub(x => x.Command).Throw(new Exception());
+
+                var sender = new ImmediateSender(new ImmediateSender.Configuration() { StatsdUDP = _udp });
+                sender.Send(metric);
+                Assert.Pass();
+            }
+
+            [Test]
+            public void does_not_blow_up_if_udp_send_throws()
+            {
+                var udpStub = MockRepository.GenerateStub<IStatsdUDP>();
+                udpStub.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 1 };
+                var sender = new ImmediateSender(new ImmediateSender.Configuration() { StatsdUDP = udpStub });
+                sender.Send(metric);
+                Assert.Pass();
+            }
+
+            [Test]
+            public void sends_metric_immediately()
+            {
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 5 };
+                var sender = new ImmediateSender(new ImmediateSender.Configuration() { StatsdUDP = _udp });
+                sender.Send(metric);
+
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((string)argsPerCall[0][0]), Is.EqualTo(metric.Command));
+            }
+
+            [Test]
+            public void sends_multiple_metrics_individually()
+            {
+                var metric1 = new Counting() { Name = "testMetric", ValueAsInt = 5 };
+                var metric2 = new Timing() { Name = "testtimer", ValueAsInt = 10 };
+
+                var sender = new ImmediateSender(new ImmediateSender.Configuration() { StatsdUDP = _udp });
+                sender.Send(metric1);
+                sender.Send(metric2);
+
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(2));
+                Assert.That(((string)argsPerCall[0][0]), Is.EqualTo(metric1.Command));
+                Assert.That(((string)argsPerCall[1][0]), Is.EqualTo(metric2.Command));
+            }
+        }
+
+        public class ThreadSafeConsumerProducerSenderTests : StatsdSenderTests
+        {
+            [Test]
+            public void does_not_blow_up_if_metric_command_throws()
+            {
+                var metric = MockRepository.GenerateStub<Counting>();
+                metric.Stub(x => x.Command).Throw(new Exception());
+
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 2000 });
+                sender.Send(metric);
+                Assert.Pass();
+            }
+
+            [Test]
+            public void does_not_blow_up_if_udp_send_throws()
+            {
+                var udpStub = MockRepository.GenerateStub<IStatsdUDP>();
+                udpStub.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 1 };
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = udpStub, MaxSendDelayMS = 2000 });
+                sender.Send(metric);
+                Assert.Pass();
+            }
+
+            [Test]
+            public void sends_after_delay()
+            {
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 5 };
+                DateTime timeCalled = DateTime.MaxValue;
+                var udpStub = MockRepository.GenerateStub<IStatsdUDP>();
+                udpStub.Stub(x => x.Send(Arg<string>.Is.Anything))
+                    .WhenCalled(m => timeCalled = DateTime.Now);
+
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = udpStub, MaxSendDelayMS = 2000 });
+                DateTime startTime = DateTime.Now;
+                sender.Send(metric);
+                Thread.Sleep(3000);
+
+                IList<object[]> argsPerCall = udpStub.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((string)argsPerCall[0][0]), Is.EqualTo(metric.Command));
+
+                var sendDelay = (timeCalled - startTime).TotalMilliseconds;
+                Assert.That(sendDelay, Is.GreaterThanOrEqualTo(2000));
+            }
+
+            [Test]
+            public void does_not_exceed_max_packet_size()
+            {
+                var udpStub = MockRepository.GenerateStub<IStatsdUDP>();
+                udpStub.Stub(x => x.MaxUDPPacketSize).Return(300);
+
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = udpStub, MaxSendDelayMS = 1000 });
+
+                for (var i = 0; i < 100; i ++)
+                {
+                    var metricName = (Guid.NewGuid()).ToString();
+                    var metric = new Counting() { Name = metricName, ValueAsInt = 1 };
+                    sender.Send(metric);
+                }
+
+                Thread.Sleep(3000);
+                IList<object[]> argsPerCall = udpStub.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                for (var i = 0; i < argsPerCall.Count; i++)
+                {
+                    var packetSize = ((string)argsPerCall[i][0]).Length;
+                    Assert.That(packetSize, Is.LessThanOrEqualTo(300));
+                }
+            }
+
+            [Test]
+            public void bundles_multiple_metrics_into_one_packet()
+            {
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var metricsToSend = 10;
+                for (var i = 0; i < metricsToSend; i++)
+                {
+                    var metricName = (Guid.NewGuid()).ToString();
+                    var metric = new Counting() { Name = metricName, ValueAsInt = 1 };
+                    sender.Send(metric);
+                }
+
+                Thread.Sleep(3000);
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                var packetsReceived = argsPerCall.Count;
+                Assert.That(packetsReceived, Is.LessThan(metricsToSend));
+            }
+
+            [Test]
+            public void does_not_block()
+            {
+                var metric = new Counting() { Name = "testMetric", ValueAsInt = 5 };
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 2000 });
+                
+                DateTime startTime = DateTime.Now;
+                sender.Send(metric);
+                DateTime endTime = DateTime.Now;
+
+                var methodCallDelay = (endTime - startTime).TotalMilliseconds;
+                Assert.That(methodCallDelay, Is.LessThan(10));
+            }
+
+            [Test]
+            public void aggregates_counters()
+            {
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var metricsToSend = 10;
+                for (var i = 0; i < metricsToSend; i++)
+                {
+                    var metric = new Counting() { Name = "testMetric", ValueAsInt = 1 };
+                    sender.Send(metric);
+                }
+
+                Thread.Sleep(1500);
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((string)argsPerCall[0][0]), Is.EqualTo("testMetric:" + metricsToSend.ToString() + "|c"));
+            }
+
+            [Test]
+            public void aggregates_gauges()
+            {
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var metricsToSend = 10;
+                Metric lastMetricSent = null;
+                for (var i = 0; i < metricsToSend; i++)
+                {
+                    var metric = new Gauge() { Name = "testMetric", ValueAsDouble = 1 };
+                    sender.Send(metric);
+                    lastMetricSent = metric;
+                }
+
+                Thread.Sleep(1500);
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((string)argsPerCall[0][0]), Is.EqualTo(lastMetricSent.Command));
+            }
+
+            [Test]
+            public void does_not_aggregate_timers()
+            {
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var metricsToSend = 10;
+                var metric = new Timing() { Name = "testMetric", ValueAsInt = 50 };
+                for (var i = 0; i < metricsToSend; i++)
+                    sender.Send(metric);
+
+                Thread.Sleep(1500);
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+
+                for (var i = 0; i < argsPerCall.Count; i ++)
+                {
+                    var packet = (string)argsPerCall[i][0];
+                    var lines = packet.Split('\n');
+                    for(var j = 0; j < lines.Length; j ++)
+                    {
+                        Assert.That(lines[j], Is.EqualTo(metric.Command));
+                    }
+                }
+            }
+
+            [Test]
+            public void stops_worker_threads_after_dispose()
+            {
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var metric = new Timing() { Name = "testMetric", ValueAsInt = 50 };
+
+                sender.Dispose();
+                sender.Send(metric);
+
+                Thread.Sleep(1500);
+                IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(0));
+            }
+        }
+
+/*
+        [Test]
+        public void increases_counter_with_value_of_X_and_sample_rate()
+        {
+            var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+            s.Send<Counting>("counter", 5, 0.1);
+
+            IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+            Assert.That(argsPerCall.Count, Is.EqualTo(1));
+            Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("counter:5|c|@0.1"));
+        }
+
+        [Test]
+        public void counting_exception_fails_silently()
+        {
+            var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+            _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+            s.Send<Counting>("counter", 5);
+            Assert.Pass();
+        }
+
+        public class Timer : StatsdTests
+        {
+            [Test]
+            public void sends_timing()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<Timing>("timer", 5);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("timer:5|ms"));
+            }
+
+            [Test]
+            public void timing_with_value_of_X_and_sample_rate()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<Timing>("timer", 5, 0.1);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("timer:5|ms|@0.1"));
+            }
+
+            [Test]
+            public void timing_exception_fails_silently()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+                s.Send<Timing>("timer", 5);
+                Assert.Pass();
+            }
+
+            [Test]
+            public void send_timer_with_lamba()
+            {
+                const string statName = "name";
+
+                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
+                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
+                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
+
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send(() => TestMethod(), statName);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
+            }
+
+            [Test]
+            public void send_timer_with_lamba_and_sampleRate_passes()
+            {
+                const string statName = "name";
+
+                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
+                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
+                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
+                _randomGenerator = MockRepository.GenerateMock<IRandomGenerator>();
+                _randomGenerator.Stub(x => x.ShouldSend(Arg<double>.Is.Anything)).Return(true);
+
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send(() => TestMethod(), statName, 0.1);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
+            }
+
+            [Test]
+            public void send_timer_with_lamba_and_sampleRate_fails()
+            {
+                const string statName = "name";
+
+                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
+                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
+                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
+                _randomGenerator = MockRepository.GenerateMock<IRandomGenerator>();
+                _randomGenerator.Stub(x => x.ShouldSend(Arg<double>.Is.Anything)).Return(false);
+
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send(() => TestMethod(), statName, 0.1);
+
+                _sender.AssertWasNotCalled(x => x.Send(Arg<Metric>.Is.Anything));
+            }
+
+            [Test]
+            public void send_timer_with_lamba_still_records_on_error_and_still_bubbles_up_exception()
+            {
+                const string statName = "name";
+
+                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
+                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
+                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
+
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+
+                Assert.Throws<InvalidOperationException>(() => s.Send(() => { throw new InvalidOperationException(); }, statName));
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
+            }
+
+            [Test]
+            public void send_timer_with_lambda()
+            {
+                const string statName = "name";
+                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
+                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
+                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
+
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send(() => TestMethod(), statName);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
+            }
+
+            [Test]
+            public void send_timer_with_lambda_and_sampleRate_passes()
+            {
+                const string statName = "name";
+                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
+                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
+                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
+                _randomGenerator = MockRepository.GenerateMock<IRandomGenerator>();
+                _randomGenerator.Stub(x => x.ShouldSend(Arg<double>.Is.Anything)).Return(true);
+
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send(() => TestMethod(), statName, 0.1);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
+            }
+
+            [Test]
+            public void send_timer_with_lambda_and_sampleRate_fails()
+            {
+                const string statName = "name";
+                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
+                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
+                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
+                _randomGenerator = MockRepository.GenerateMock<IRandomGenerator>();
+                _randomGenerator.Stub(x => x.ShouldSend(Arg<double>.Is.Anything)).Return(false);
+
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send(() => TestMethod(), statName, 0.1);
+
+                _sender.AssertWasNotCalled(x => x.Send(Arg<Metric>.Is.Anything));
+            }
+
+            [Test]
+            public void set_return_value_with_send_timer_with_lambda()
+            {
+                const string statName = "name";
+                var stopwatch = MockRepository.GenerateMock<IStopwatch>();
+                stopwatch.Stub(x => x.ElapsedMilliseconds()).Return(500);
+                _stopwatch.Stub(x => x.Get()).Return(stopwatch);
+
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                var returnValue = 0;
+                s.Send(() => returnValue = TestMethod(), statName);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("name:500|ms"));
+                Assert.That(returnValue, Is.EqualTo(5));
+            }
+        }
+
+        public class Guage : StatsdTests
+        {
+            [Test]
+            public void send_gauge_with_large_double_values()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<Gauge>("gauge", 34563478564785);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("gauge:34563478564785.000000000000000|g"));
+            }
+
+            [Test]
+            public void gauge_exception_fails_silently()
+            {
+                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<Gauge>("gauge", 5.0);
+                Assert.Pass();
+            }
+        }
+
+        public class Meter : StatsdTests
+        {
+            [Test]
+            public void send_meter()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<StatsdClient.MetricTypes.Meter>("meter", 5);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("meter:5|m"));
+            }
+
+            [Test]
+            public void meter_exception_fails_silently()
+            {
+                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+
+                s.Send<StatsdClient.MetricTypes.Meter>("meter", 5);
+                Assert.Pass();
+            }
+        }
+
+        public class Histogram : StatsdTests
+        {
+            [Test]
+            public void sends_histogram()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<StatsdClient.MetricTypes.Histogram>("histogram", 5);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("histogram:5|h"));
+            }
+
+            [Test]
+            public void histogram_exception_fails_silently()
+            {
+                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<StatsdClient.MetricTypes.Histogram>("histogram", 5);
+                Assert.Pass();
+            }
+        }
+
+        public class Set : StatsdTests
+        {
+            [Test]
+            public void sets_set_with_string_value()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<StatsdClient.MetricTypes.Set>("set", "34563478564785xyz");
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("set:34563478564785xyz|s"));
+            }
+
+            [Test]
+            public void set_exception_fails_silently()
+            {
+                _udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<StatsdClient.MetricTypes.Set>("set", "silent-exception-test");
+                Assert.Pass();
+            }
+        }
+
+        public class Combination : StatsdTests
+        {
+            [Test]
+            public void send_one_counter_and_one_timer_shows_in_commands()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<Counting>("counter", 1, 0.1);
+                s.Send<Timing>("timer", 1);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(2));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("counter:1|c|@0.1"));
+                Assert.That(((Metric)argsPerCall[1][0]).Command, Is.EqualTo("timer:1|ms"));
+            }
+
+            [Test]
+            public void send_one_counter_and_one_timer_with_no_sample_rate_shows_in_commands()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                s.Send<Counting>("counter", 1);
+                s.Send<Timing>("timer", 1);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(2));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("counter:1|c"));
+                Assert.That(((Metric)argsPerCall[1][0]).Command, Is.EqualTo("timer:1|ms"));
+            }
+        }
+
+        public class NamePrefixing : StatsdTests
+        {
+            [Test]
+            public void set_prefix_on_stats_name_when_calling_send()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender, Prefix = "a.prefix." });
+                s.Send<Counting>("counter", 5);
+
+                IList<object[]> argsPerCall = _sender.GetArgumentsForCallsMadeOn(x => x.Send(Arg<Metric>.Is.Anything));
+                Assert.That(argsPerCall.Count, Is.EqualTo(1));
+                Assert.That(((Metric)argsPerCall[0][0]).Command, Is.EqualTo("a.prefix.counter:5|c"));
+            }
+        }
+
+        public class Concurrency : StatsdTests
+        {
+            [Test]
+            public void can_concurrently_send_integer_metrics()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                Parallel.For(0, 50000, x => Assert.DoesNotThrow(() => s.Send<Counting>("name", 5)));
+            }
+
+            [Test]
+            public void can_concurrently_send_double_metrics()
+            {
+                var s = new Statsd(new Statsd.Configuration() { Udp = _udp, RandomGenerator = _randomGenerator, StopwatchFactory = _stopwatch, Sender = _sender });
+                Parallel.For(0, 50000, x => Assert.DoesNotThrow(() => s.Send<Gauge>("name", 5d)));
+            }
+        }
+
+        private static int TestMethod()
+        {
+            return 5;
+        }
+ */ 
+    }
+}

--- a/src/Tests/StatsdSenderTests.cs
+++ b/src/Tests/StatsdSenderTests.cs
@@ -53,7 +53,8 @@ namespace Tests
                 var metric = MockRepository.GenerateStub<Counting>();
                 metric.Stub(x => x.Command).Throw(new Exception());
 
-                var sender = new ImmediateSender(new ImmediateSender.Configuration() { StatsdUDP = _udp });
+                var sender = new ImmediateSender();
+                sender.StatsdUDP = _udp;
                 sender.Send(metric);
                 Assert.Pass();
             }
@@ -64,7 +65,8 @@ namespace Tests
                 var udpStub = MockRepository.GenerateStub<IStatsdUDP>();
                 udpStub.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
                 var metric = new Counting() { Name = "testMetric", ValueAsInt = 1 };
-                var sender = new ImmediateSender(new ImmediateSender.Configuration() { StatsdUDP = udpStub });
+                var sender = new ImmediateSender();
+                sender.StatsdUDP = udpStub;
                 sender.Send(metric);
                 Assert.Pass();
             }
@@ -73,7 +75,8 @@ namespace Tests
             public void sends_metric_immediately()
             {
                 var metric = new Counting() { Name = "testMetric", ValueAsInt = 5 };
-                var sender = new ImmediateSender(new ImmediateSender.Configuration() { StatsdUDP = _udp });
+                var sender = new ImmediateSender();
+                sender.StatsdUDP = _udp;
                 sender.Send(metric);
 
                 IList<object[]> argsPerCall = _udp.GetArgumentsForCallsMadeOn(x => x.Send(Arg<string>.Is.Anything));
@@ -87,7 +90,8 @@ namespace Tests
                 var metric1 = new Counting() { Name = "testMetric", ValueAsInt = 5 };
                 var metric2 = new Timing() { Name = "testtimer", ValueAsInt = 10 };
 
-                var sender = new ImmediateSender(new ImmediateSender.Configuration() { StatsdUDP = _udp });
+                var sender = new ImmediateSender();
+                sender.StatsdUDP = _udp;
                 sender.Send(metric1);
                 sender.Send(metric2);
 
@@ -106,7 +110,8 @@ namespace Tests
                 var metric = MockRepository.GenerateStub<Counting>();
                 metric.Stub(x => x.Command).Throw(new Exception());
 
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 2000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 2000 });
+                sender.StatsdUDP = _udp;
                 sender.Send(metric);
                 Assert.Pass();
             }
@@ -117,7 +122,8 @@ namespace Tests
                 var udpStub = MockRepository.GenerateStub<IStatsdUDP>();
                 udpStub.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
                 var metric = new Counting() { Name = "testMetric", ValueAsInt = 1 };
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = udpStub, MaxSendDelayMS = 2000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 2000 });
+                sender.StatsdUDP = udpStub;
                 sender.Send(metric);
                 Assert.Pass();
             }
@@ -131,7 +137,8 @@ namespace Tests
                 udpStub.Stub(x => x.Send(Arg<string>.Is.Anything))
                     .WhenCalled(m => timeCalled = DateTime.Now);
 
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = udpStub, MaxSendDelayMS = 2000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 2000 });
+                sender.StatsdUDP = udpStub;
                 DateTime startTime = DateTime.Now;
                 sender.Send(metric);
                 Thread.Sleep(3000);
@@ -150,7 +157,8 @@ namespace Tests
                 var udpStub = MockRepository.GenerateStub<IStatsdUDP>();
                 udpStub.Stub(x => x.MaxUDPPacketSize).Return(300);
 
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = udpStub, MaxSendDelayMS = 1000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 1000 });
+                sender.StatsdUDP = udpStub;
 
                 for (var i = 0; i < 100; i ++)
                 {
@@ -171,7 +179,8 @@ namespace Tests
             [Test]
             public void bundles_multiple_metrics_into_one_packet()
             {
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 1000 });
+                sender.StatsdUDP = _udp;
                 var metricsToSend = 10;
                 for (var i = 0; i < metricsToSend; i++)
                 {
@@ -190,7 +199,8 @@ namespace Tests
             public void does_not_block()
             {
                 var metric = new Counting() { Name = "testMetric", ValueAsInt = 5 };
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 2000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 2000 });
+                sender.StatsdUDP = _udp;
                 
                 DateTime startTime = DateTime.Now;
                 sender.Send(metric);
@@ -203,7 +213,8 @@ namespace Tests
             [Test]
             public void aggregates_counters()
             {
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 1000 });
+                sender.StatsdUDP = _udp;
                 var metricsToSend = 10;
                 for (var i = 0; i < metricsToSend; i++)
                 {
@@ -220,7 +231,8 @@ namespace Tests
             [Test]
             public void aggregates_gauges()
             {
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 1000 });
+                sender.StatsdUDP = _udp;
                 var metricsToSend = 10;
                 Metric lastMetricSent = null;
                 for (var i = 0; i < metricsToSend; i++)
@@ -239,7 +251,8 @@ namespace Tests
             [Test]
             public void does_not_aggregate_timers()
             {
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 1000 });
+                sender.StatsdUDP = _udp;
                 var metricsToSend = 10;
                 var metric = new Timing() { Name = "testMetric", ValueAsInt = 50 };
                 for (var i = 0; i < metricsToSend; i++)
@@ -262,7 +275,8 @@ namespace Tests
             [Test]
             public void stops_worker_threads_after_dispose()
             {
-                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { StatsdUDP = _udp, MaxSendDelayMS = 1000 });
+                var sender = new ThreadSafeConsumerProducerSender(new ThreadSafeConsumerProducerSender.Configuration() { MaxSendDelayMS = 1000 });
+                sender.StatsdUDP = _udp;
                 var metric = new Timing() { Name = "testMetric", ValueAsInt = 50 };
 
                 sender.Dispose();

--- a/src/Tests/StatsdUDPTests.cs
+++ b/src/Tests/StatsdUDPTests.cs
@@ -1,155 +1,166 @@
-//using System;
-//using System.Threading;
-//using System.Collections.Generic;
-//using NUnit.Framework;
-//using StatsdClient;
-//using Tests.Helpers;
+using System;
+using System.Threading;
+using System.Collections.Generic;
+using NUnit.Framework;
+using StatsdClient;
+using Tests.Helpers;
+using StatsdClient.Senders;
 
 
-//namespace Tests
-//{
-//    // Most of StatsUDP is tested in StatsdUnitTests. This is mainly to test the splitting of oversized
-//    // UDP packets
-//    [TestFixture]
-//    public class StatsUDPTests
-//    {
-//        private UdpListener udpListener;
-//        private Thread listenThread;
-//        private const int serverPort = 23483;
-//        private const string serverName = "127.0.0.1";
-//        private StatsdUDP udp;
-//        private Statsd statsd;
-//        private List<string> lastPulledMessages;
+namespace Tests
+{
+    // Most of StatsUDP is tested in StatsdUnitTests. This is mainly to test the splitting of oversized
+    // UDP packets
+    [TestFixture]
+    public class StatsUDPTests
+    {
+        private UdpListener udpListener;
+        private Thread listenThread;
+        private const int serverPort = 23483;
+        private const string serverName = "127.0.0.1";
+        private StatsdUDP udp;
+        private List<string> lastPulledMessages;
 
-//        [TestFixtureSetUp]
-//        public void SetUpUdpListenerAndStatsd() 
-//        {
-//            udpListener = new UdpListener(serverName, serverPort);
-//            var metricsConfig = new MetricsConfig { StatsdServerName = serverName };
-//            StatsdClient.Metrics.Configure(metricsConfig);
-//            udp = new StatsdUDP(serverName, serverPort);
-//            statsd = new Statsd(udp);
-//        }
+        [TestFixtureSetUp]
+        public void SetUpUdpListenerAndStatsd()
+        {
+            udpListener = new UdpListener(serverName, serverPort);
+            udp = new StatsdUDP(serverName, serverPort);
+        }
 
-//        [TestFixtureTearDown]
-//        public void TearDownUdpListener() 
-//        {
-//            udpListener.Dispose();
-//            udp.Dispose();
-//        }
+        [TestFixtureTearDown]
+        public void TearDownUdpListener()
+        {
+            udpListener.Dispose();
+            udp.Dispose();
+        }
 
-//        [SetUp]
-//        public void UdpListenerThread()
-//        {
-//            lastPulledMessages = new List<string>();
-//            listenThread = new Thread(new ParameterizedThreadStart(udpListener.Listen));
-//        }
+        [SetUp]
+        public void UdpListenerThread()
+        {
+            lastPulledMessages = new List<string>();
+            listenThread = new Thread(new ParameterizedThreadStart(udpListener.Listen));
+        }
 
-//        [TearDown]
-//        public void ClearUdpListenerMessages()
-//        {
-//            udpListener.GetAndClearLastMessages(); // just to be sure that nothing is left over
-//        }
+        [TearDown]
+        public void ClearUdpListenerMessages()
+        {
+            udpListener.GetAndClearLastMessages(); // just to be sure that nothing is left over
+        }
 
-//        // Test helper. Waits until the listener is done receiving a message,
-//        // then asserts that the passed string is equal to the message received.
-//        private void AssertWasReceived(string shouldBe, int index = 0)
-//        {
-//            if (lastPulledMessages.Count == 0)
-//            {
-//                // Stall until the the listener receives a message or times out
-//                while(listenThread.IsAlive);
-//                lastPulledMessages = udpListener.GetAndClearLastMessages();
-//            }
+        // Test helper. Waits until the listener is done receiving a message,
+        // then asserts that the passed string is equal to the message received.
+        private void AssertWasReceived(string shouldBe, int index = 0)
+        {
+            if (lastPulledMessages.Count == 0)
+            {
+                // Stall until the the listener receives a message or times out
+                while (listenThread.IsAlive) ;
+                lastPulledMessages = udpListener.GetAndClearLastMessages();
+            }
 
-//            string actual;
+            string actual;
 
-//            try
-//            {
-//                actual = lastPulledMessages[index];
-//            }
-//            catch (System.ArgumentOutOfRangeException)
-//            {
-//                actual = null;
-//            }
-//            Assert.AreEqual(shouldBe, actual);
-//        }
+            try
+            {
+                actual = lastPulledMessages[index];
+            }
+            catch (System.ArgumentOutOfRangeException)
+            {
+                actual = null;
+            }
+            Assert.AreEqual(shouldBe, actual);
+        }
 
-//        [Test]
-//        public void send()
-//        {
-//            // (Sanity test)
-//            listenThread.Start();
-//            udp.Send("test-metric");
-//            AssertWasReceived("test-metric");
-//        }
+        [Test]
+        public void send()
+        {
+            // (Sanity test)
+            listenThread.Start();
+            udp.Send("test-metric");
+            AssertWasReceived("test-metric");
+        }
 
-//        [Test]
-//        public void send_equal_to_udp_packet_limit_is_still_sent()
-//        {
-//            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize);
-//            listenThread.Start();
-//            udp.Send(msg);
-//            // As long as we're at or below the limit, the packet should still be sent 
-//            AssertWasReceived(msg);
-//        }
+        [Test]
+        public void send_equal_to_udp_packet_limit_is_still_sent()
+        {
+            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize);
+            listenThread.Start();
+            udp.Send(msg);
+            // As long as we're at or below the limit, the packet should still be sent 
+            AssertWasReceived(msg);
+        }
 
-//        [Test]
-//        public void send_unsplittable_oversized_udp_packets_are_not_split_or_sent_and_no_exception_is_raised()
-//        {
-//            // This message will be one byte longer than the theoretical limit of a UDP packet
-//            var msg = new String('f', 65508);
-//            listenThread.Start();
-//            statsd.Add<Statsd.Counting>(msg, 1);
-//            statsd.Send();
-//            // It shouldn't be split or sent, and no exceptions should be raised.
-//            AssertWasReceived(null);
-//        }
+        [Test]
+        public void send_unsplittable_oversized_udp_packets_are_not_split_or_sent_and_no_exception_is_raised()
+        {
+            // This message will be one byte longer than the theoretical limit of a UDP packet
+            var msg = new String('f', 65508);
+            listenThread.Start();
 
-//        [Test]
-//        public void send_oversized_udp_packets_are_split_if_possible()
-//        {
-//            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize - 15);
-//            listenThread.Start(3); // Listen for 3 messages
-//            statsd.Add<Statsd.Counting>(msg, 1);
-//            statsd.Add<Statsd.Timing>(msg, 2);
-//            statsd.Send();
-//            // These two metrics should be split as their combined lengths exceed the maximum packet size
-//            AssertWasReceived(String.Format("{0}:1|c", msg), 0);
-//            AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
-//            // No extra metric should be sent at the end
-//            AssertWasReceived(null, 2);
-//        }
+            var statsd = new Statsd(new Statsd.Configuration() { Udp = udp, Sender = new ImmediateSender() });
+            statsd.Send<Statsd.Counting>(msg, 1);
+            // It shouldn't be split or sent, and no exceptions should be raised.
+            AssertWasReceived(null);
+        }
 
-//        [Test]
-//        public void send_oversized_udp_packets_are_split_if_possible_with_multiple_messages_in_one_packet()
-//        {
-//            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize / 2);
-//            listenThread.Start(3);
-//            statsd.Add<Statsd.Counting>("counter", 1);
-//            statsd.Add<Statsd.Counting>(msg, 2);
-//            statsd.Add<Statsd.Counting>(msg, 3);
-//            statsd.Send();
-//            // Make sure that a split packet can contain mulitple metrics
-//            AssertWasReceived(String.Format("counter:1|c\n{0}:2|c", msg), 0);
-//            AssertWasReceived(String.Format("{0}:3|c", msg), 1);
-//            AssertWasReceived(null, 2);
-//        }
+        [Test]
+        public void send_oversized_udp_packets_are_split_if_possible()
+        {
+            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize - 15);
+            listenThread.Start(3); // Listen for 3 messages
 
-//        [Test]
-//        public void set_max_udp_packet_size()
-//        {
-//            // Make sure that we can set the max UDP packet size
-//            udp = new StatsdUDP(serverName, serverPort, 10);
-//            statsd = new Statsd(udp);
-//            var msg = new String('f', 5);
-//            listenThread.Start(2);
-//            statsd.Add<Statsd.Counting>(msg, 1);
-//            statsd.Add<Statsd.Timing>(msg, 2);
-//            statsd.Send();
-//            // Since our packet size limit is now 10, this (short) message should still be split
-//            AssertWasReceived(String.Format("{0}:1|c", msg), 0);
-//            AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
-//        }
-//    }
-//}
+            var sender = new BatchSender();
+            var statsd = new Statsd(new Statsd.Configuration() { Udp = udp, Sender = sender });
+
+            statsd.Send<Statsd.Counting>(msg, 1);
+            statsd.Send<Statsd.Timing>(msg, 2);
+            sender.Flush();
+
+            // These two metrics should be split as their combined lengths exceed the maximum packet size
+            AssertWasReceived(String.Format("{0}:1|c", msg), 0);
+            AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
+            // No extra metric should be sent at the end
+            AssertWasReceived(null, 2);
+        }
+
+        [Test]
+        public void send_oversized_udp_packets_are_split_if_possible_with_multiple_messages_in_one_packet()
+        {
+            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize / 2);
+            listenThread.Start(3);
+
+            var sender = new BatchSender();
+            var statsd = new Statsd(new Statsd.Configuration() { Udp = udp, Sender = sender });
+
+            statsd.Send<Statsd.Counting>("counter", 1);
+            statsd.Send<Statsd.Counting>(msg, 2);
+            statsd.Send<Statsd.Counting>(msg, 3);
+            sender.Flush();
+
+            // Make sure that a split packet can contain mulitple metrics
+            AssertWasReceived(String.Format("counter:1|c\n{0}:2|c", msg), 0);
+            AssertWasReceived(String.Format("{0}:3|c", msg), 1);
+            AssertWasReceived(null, 2);
+        }
+
+        [Test]
+        public void set_max_udp_packet_size()
+        {
+            // Make sure that we can set the max UDP packet size
+            udp = new StatsdUDP(serverName, serverPort, 10);
+            var msg = new String('f', 5);
+            listenThread.Start(2);
+
+            var sender = new BatchSender();
+            var statsd = new Statsd(new Statsd.Configuration() { Udp = udp, Sender = sender });
+            statsd.Send<Statsd.Counting>(msg, 1);
+            statsd.Send<Statsd.Timing>(msg, 2);
+            sender.Flush();
+
+            // Since our packet size limit is now 10, this (short) message should still be split
+            AssertWasReceived(String.Format("{0}:1|c", msg), 0);
+            AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
+        }
+    }
+}

--- a/src/Tests/StatsdUDPTests.cs
+++ b/src/Tests/StatsdUDPTests.cs
@@ -1,155 +1,155 @@
-using System;
-using System.Threading;
-using System.Collections.Generic;
-using NUnit.Framework;
-using StatsdClient;
-using Tests.Helpers;
+//using System;
+//using System.Threading;
+//using System.Collections.Generic;
+//using NUnit.Framework;
+//using StatsdClient;
+//using Tests.Helpers;
 
 
-namespace Tests
-{
-    // Most of StatsUDP is tested in StatsdUnitTests. This is mainly to test the splitting of oversized
-    // UDP packets
-    [TestFixture]
-    public class StatsUDPTests
-    {
-        private UdpListener udpListener;
-        private Thread listenThread;
-        private const int serverPort = 23483;
-        private const string serverName = "127.0.0.1";
-        private StatsdUDP udp;
-        private Statsd statsd;
-        private List<string> lastPulledMessages;
+//namespace Tests
+//{
+//    // Most of StatsUDP is tested in StatsdUnitTests. This is mainly to test the splitting of oversized
+//    // UDP packets
+//    [TestFixture]
+//    public class StatsUDPTests
+//    {
+//        private UdpListener udpListener;
+//        private Thread listenThread;
+//        private const int serverPort = 23483;
+//        private const string serverName = "127.0.0.1";
+//        private StatsdUDP udp;
+//        private Statsd statsd;
+//        private List<string> lastPulledMessages;
 
-        [TestFixtureSetUp]
-        public void SetUpUdpListenerAndStatsd() 
-        {
-            udpListener = new UdpListener(serverName, serverPort);
-            var metricsConfig = new MetricsConfig { StatsdServerName = serverName };
-            StatsdClient.Metrics.Configure(metricsConfig);
-            udp = new StatsdUDP(serverName, serverPort);
-            statsd = new Statsd(udp);
-        }
+//        [TestFixtureSetUp]
+//        public void SetUpUdpListenerAndStatsd() 
+//        {
+//            udpListener = new UdpListener(serverName, serverPort);
+//            var metricsConfig = new MetricsConfig { StatsdServerName = serverName };
+//            StatsdClient.Metrics.Configure(metricsConfig);
+//            udp = new StatsdUDP(serverName, serverPort);
+//            statsd = new Statsd(udp);
+//        }
 
-        [TestFixtureTearDown]
-        public void TearDownUdpListener() 
-        {
-            udpListener.Dispose();
-            udp.Dispose();
-        }
+//        [TestFixtureTearDown]
+//        public void TearDownUdpListener() 
+//        {
+//            udpListener.Dispose();
+//            udp.Dispose();
+//        }
 
-        [SetUp]
-        public void UdpListenerThread()
-        {
-            lastPulledMessages = new List<string>();
-            listenThread = new Thread(new ParameterizedThreadStart(udpListener.Listen));
-        }
+//        [SetUp]
+//        public void UdpListenerThread()
+//        {
+//            lastPulledMessages = new List<string>();
+//            listenThread = new Thread(new ParameterizedThreadStart(udpListener.Listen));
+//        }
 
-        [TearDown]
-        public void ClearUdpListenerMessages()
-        {
-            udpListener.GetAndClearLastMessages(); // just to be sure that nothing is left over
-        }
+//        [TearDown]
+//        public void ClearUdpListenerMessages()
+//        {
+//            udpListener.GetAndClearLastMessages(); // just to be sure that nothing is left over
+//        }
 
-        // Test helper. Waits until the listener is done receiving a message,
-        // then asserts that the passed string is equal to the message received.
-        private void AssertWasReceived(string shouldBe, int index = 0)
-        {
-            if (lastPulledMessages.Count == 0)
-            {
-                // Stall until the the listener receives a message or times out
-                while(listenThread.IsAlive);
-                lastPulledMessages = udpListener.GetAndClearLastMessages();
-            }
+//        // Test helper. Waits until the listener is done receiving a message,
+//        // then asserts that the passed string is equal to the message received.
+//        private void AssertWasReceived(string shouldBe, int index = 0)
+//        {
+//            if (lastPulledMessages.Count == 0)
+//            {
+//                // Stall until the the listener receives a message or times out
+//                while(listenThread.IsAlive);
+//                lastPulledMessages = udpListener.GetAndClearLastMessages();
+//            }
 
-            string actual;
+//            string actual;
 
-            try
-            {
-                actual = lastPulledMessages[index];
-            }
-            catch (System.ArgumentOutOfRangeException)
-            {
-                actual = null;
-            }
-            Assert.AreEqual(shouldBe, actual);
-        }
+//            try
+//            {
+//                actual = lastPulledMessages[index];
+//            }
+//            catch (System.ArgumentOutOfRangeException)
+//            {
+//                actual = null;
+//            }
+//            Assert.AreEqual(shouldBe, actual);
+//        }
 
-        [Test]
-        public void send()
-        {
-            // (Sanity test)
-            listenThread.Start();
-            udp.Send("test-metric");
-            AssertWasReceived("test-metric");
-        }
+//        [Test]
+//        public void send()
+//        {
+//            // (Sanity test)
+//            listenThread.Start();
+//            udp.Send("test-metric");
+//            AssertWasReceived("test-metric");
+//        }
 
-        [Test]
-        public void send_equal_to_udp_packet_limit_is_still_sent()
-        {
-            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize);
-            listenThread.Start();
-            udp.Send(msg);
-            // As long as we're at or below the limit, the packet should still be sent 
-            AssertWasReceived(msg);
-        }
+//        [Test]
+//        public void send_equal_to_udp_packet_limit_is_still_sent()
+//        {
+//            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize);
+//            listenThread.Start();
+//            udp.Send(msg);
+//            // As long as we're at or below the limit, the packet should still be sent 
+//            AssertWasReceived(msg);
+//        }
 
-        [Test]
-        public void send_unsplittable_oversized_udp_packets_are_not_split_or_sent_and_no_exception_is_raised()
-        {
-            // This message will be one byte longer than the theoretical limit of a UDP packet
-            var msg = new String('f', 65508);
-            listenThread.Start();
-            statsd.Add<Statsd.Counting>(msg, 1);
-            statsd.Send();
-            // It shouldn't be split or sent, and no exceptions should be raised.
-            AssertWasReceived(null);
-        }
+//        [Test]
+//        public void send_unsplittable_oversized_udp_packets_are_not_split_or_sent_and_no_exception_is_raised()
+//        {
+//            // This message will be one byte longer than the theoretical limit of a UDP packet
+//            var msg = new String('f', 65508);
+//            listenThread.Start();
+//            statsd.Add<Statsd.Counting>(msg, 1);
+//            statsd.Send();
+//            // It shouldn't be split or sent, and no exceptions should be raised.
+//            AssertWasReceived(null);
+//        }
 
-        [Test]
-        public void send_oversized_udp_packets_are_split_if_possible()
-        {
-            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize - 15);
-            listenThread.Start(3); // Listen for 3 messages
-            statsd.Add<Statsd.Counting>(msg, 1);
-            statsd.Add<Statsd.Timing>(msg, 2);
-            statsd.Send();
-            // These two metrics should be split as their combined lengths exceed the maximum packet size
-            AssertWasReceived(String.Format("{0}:1|c", msg), 0);
-            AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
-            // No extra metric should be sent at the end
-            AssertWasReceived(null, 2);
-        }
+//        [Test]
+//        public void send_oversized_udp_packets_are_split_if_possible()
+//        {
+//            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize - 15);
+//            listenThread.Start(3); // Listen for 3 messages
+//            statsd.Add<Statsd.Counting>(msg, 1);
+//            statsd.Add<Statsd.Timing>(msg, 2);
+//            statsd.Send();
+//            // These two metrics should be split as their combined lengths exceed the maximum packet size
+//            AssertWasReceived(String.Format("{0}:1|c", msg), 0);
+//            AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
+//            // No extra metric should be sent at the end
+//            AssertWasReceived(null, 2);
+//        }
 
-        [Test]
-        public void send_oversized_udp_packets_are_split_if_possible_with_multiple_messages_in_one_packet()
-        {
-            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize / 2);
-            listenThread.Start(3);
-            statsd.Add<Statsd.Counting>("counter", 1);
-            statsd.Add<Statsd.Counting>(msg, 2);
-            statsd.Add<Statsd.Counting>(msg, 3);
-            statsd.Send();
-            // Make sure that a split packet can contain mulitple metrics
-            AssertWasReceived(String.Format("counter:1|c\n{0}:2|c", msg), 0);
-            AssertWasReceived(String.Format("{0}:3|c", msg), 1);
-            AssertWasReceived(null, 2);
-        }
+//        [Test]
+//        public void send_oversized_udp_packets_are_split_if_possible_with_multiple_messages_in_one_packet()
+//        {
+//            var msg = new String('f', MetricsConfig.DefaultStatsdMaxUDPPacketSize / 2);
+//            listenThread.Start(3);
+//            statsd.Add<Statsd.Counting>("counter", 1);
+//            statsd.Add<Statsd.Counting>(msg, 2);
+//            statsd.Add<Statsd.Counting>(msg, 3);
+//            statsd.Send();
+//            // Make sure that a split packet can contain mulitple metrics
+//            AssertWasReceived(String.Format("counter:1|c\n{0}:2|c", msg), 0);
+//            AssertWasReceived(String.Format("{0}:3|c", msg), 1);
+//            AssertWasReceived(null, 2);
+//        }
 
-        [Test]
-        public void set_max_udp_packet_size()
-        {
-            // Make sure that we can set the max UDP packet size
-            udp = new StatsdUDP(serverName, serverPort, 10);
-            statsd = new Statsd(udp);
-            var msg = new String('f', 5);
-            listenThread.Start(2);
-            statsd.Add<Statsd.Counting>(msg, 1);
-            statsd.Add<Statsd.Timing>(msg, 2);
-            statsd.Send();
-            // Since our packet size limit is now 10, this (short) message should still be split
-            AssertWasReceived(String.Format("{0}:1|c", msg), 0);
-            AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
-        }
-    }
-}
+//        [Test]
+//        public void set_max_udp_packet_size()
+//        {
+//            // Make sure that we can set the max UDP packet size
+//            udp = new StatsdUDP(serverName, serverPort, 10);
+//            statsd = new Statsd(udp);
+//            var msg = new String('f', 5);
+//            listenThread.Start(2);
+//            statsd.Add<Statsd.Counting>(msg, 1);
+//            statsd.Add<Statsd.Timing>(msg, 2);
+//            statsd.Send();
+//            // Since our packet size limit is now 10, this (short) message should still be split
+//            AssertWasReceived(String.Format("{0}:1|c", msg), 0);
+//            AssertWasReceived(String.Format("{0}:2|ms", msg), 1);
+//        }
+//    }
+//}

--- a/src/Tests/UdpListener.cs
+++ b/src/Tests/UdpListener.cs
@@ -37,7 +37,7 @@ namespace Tests
                 lastReceivedMessages = new List<string>();
                 localIpEndPoint = new IPEndPoint(IPAddress.Parse(hostname), port);
                 socket = new UdpClient(localIpEndPoint);
-                socket.Client.ReceiveTimeout = 10000;
+                socket.Client.ReceiveTimeout = 5000;
                 senderIpEndPoint = new IPEndPoint(IPAddress.Any, 0);
             }
 

--- a/src/Tests/UdpListener.cs
+++ b/src/Tests/UdpListener.cs
@@ -37,7 +37,7 @@ namespace Tests
                 lastReceivedMessages = new List<string>();
                 localIpEndPoint = new IPEndPoint(IPAddress.Parse(hostname), port);
                 socket = new UdpClient(localIpEndPoint);
-                socket.Client.ReceiveTimeout = 2000;
+                socket.Client.ReceiveTimeout = 10000;
                 senderIpEndPoint = new IPEndPoint(IPAddress.Any, 0);
             }
 


### PR DESCRIPTION
This PR adds several new features to the statsd client to increase performance and provide thread safety.

- Thread safe
- Bundles multiple metrics into a UDP packet (up to max packet size) for increased performance.
- Aggregates metric types that can be aggregated (counters and gauges) and sends the aggregated result rather than sending the same metric multiple times within the same packet
- Uses the producer/consumer pattern to allow a different number of producer threads vs. sender thread(s)

Some classes are significantly changed from how they were before, so if you don't want to accept it I totally understand, but I think it's valuable, so I wanted to make it available for others that may need it.  The user API is identical to before, with the exception that the Add methods are no longer there because bundling of metrics is handled automatically behind the scenes.

I implemented these changes because I am using statsd in a process that has many threads (Azure worker roles that have 25+ threads listening on Service Bus message queues), and the existing implementation was not thread safe when called by multiple threads (there was a possibilty of metrics getting lost under race conditions and never being delivered to the server).  Using a separate client instance for each thread was also not an option for me, because having 25 threads that are all sending their own stats is less than ideal.

With this PR, an unlimited number of threads can all safely send metrics to the same client instance.  The client uses a .NET 4 BlockingCollection to add metrics to be sent into a thread safe queue without requiring a lock, so it runs very fast and is thread safe.  A configurable number of consumer worker thread(s) monitor this queue and send metrics to the server.  In my own project, I have this configured for 3 threads.  The default value in the code if not specified is 1 thread, which is probably fine for most applications.

There are new two configuration options that control send behavior.

| Configuration Option | Default Value | Description                                                                                                                                                                                                                                                                                                                                      |
|----------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| MaxSendDelayMS       | 5000          | Maximum amount of time (in milliseconds), to wait for additional metrics to be sent before bundling up the metrics and sending them to the server.  It is important that this value is always smaller than the flush interval.                                                                                                                   |
| MaxThreads           | 1             | Number of worker threads that will be used to send metrics to StatsD.  In very high volume use cases, a single worker thread may not be able to keep up with all of the metrics to be sent.  In that case, the number of threads can be increased with this option.  In most cases, the default value of one worker thread should be sufficient. |

In most cases the default values are fine, and you can continue to initialize the Statsd or Metrics classes in the way that they were used previously.  

If you do need to configure these options to different values, create an instance of the ThreadSafeConsumerProducerSender using the appropriate configuration options, and use it as the value for the Sender property in your MetricsConfig object.

``` C#
var metricsConfig = new MetricsConfig
{
  StatsdServerName = "host.name",
  Prefix = "myApp",
  Sender = new ThreadSafeConsumerProducerSender(
    new ThreadSafeConsumerProducerSender.Configuration() { 
      MaxSendDelayMS = 5000,
      MaxThreads = 3
};
Metrics.Configure(metricsConfig);

// Or, if using the Statsd class directly:
var sender = new ThreadSafeConsumerProducerSender(
  new ThreadSafeConsumerProducerSender.Configuration() {
    MaxSendDelayMS = 5000,
    MaxThreads = 3
  });
var statsd = new Statsd(new Statsd.Configuration() { Udp = ..., Sender = sender });
```
