### PR TITLE
Gauge option for Δ values

### DIFF
--- a/src/StatsdClient/IStatsd.cs
+++ b/src/StatsdClient/IStatsd.cs
@@ -12,6 +12,7 @@ namespace StatsdClient
 
         void Send<TCommandType>(string name, double value) where TCommandType : IAllowsDouble;
         void Add<TCommandType>(string name, double value) where TCommandType : IAllowsDouble;
+        void Send<TCommandType>(string name, double value, bool isDeltaValue) where TCommandType : IAllowsDouble, IAllowsDelta;
 
         void Send<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate;
         void Add<TCommandType>(string name, int value, double sampleRate) where TCommandType : IAllowsInteger, IAllowsSampleRate;

--- a/src/StatsdClient/Metrics.cs
+++ b/src/StatsdClient/Metrics.cs
@@ -42,20 +42,29 @@ namespace StatsdClient
         }
 
         /// <summary>
-        /// Emit gauge value to statsd
+        /// Modify the current value of the gauge with the given value 
+        /// </summary>
+        /// <param name="statName"></param>
+        /// <param name="deltaValue"></param>
+        public static void GaugeDelta(string statName, double deltaValue)
+        {
+            _statsD.Send<Statsd.Gauge>(BuildNamespacedStatName(statName), deltaValue, true);
+        }
+
+        /// <summary>
+        /// Set the gauge to the given absolute value
         /// </summary>
         /// <param name="statName"></param>
         /// <param name="value"></param>
-        /// <param name="isDeltaValue">
-        /// When set to true the given value will be submitted as a delta value 
-        /// so the value is modified in statsd instead of set to the given value
-        /// </param>
-        public static void Gauge(string statName, double value, bool isDeltaValue=false)
+        public static void GaugeAbsoluteValue(string statName, double absoluteValue)
         {
-            if(isDeltaValue)
-                _statsD.Send<Statsd.Gauge>(BuildNamespacedStatName(statName), value, true);
-            else
-                _statsD.Send<Statsd.Gauge>(BuildNamespacedStatName(statName), value, false);
+            _statsD.Send<Statsd.Gauge>(BuildNamespacedStatName(statName), absoluteValue, false);
+        }
+
+        [Obsolete("Will be removed in future version. Use explicit GaugeDelta or GaugeAbsoluteValue instead.")]
+        public static void Gauge(string statName, double value)
+        {
+            GaugeAbsoluteValue(statName, value);
         }
 
         public static void Timer(string statName, int value, double sampleRate = 1)

--- a/src/StatsdClient/Metrics.cs
+++ b/src/StatsdClient/Metrics.cs
@@ -41,9 +41,21 @@ namespace StatsdClient
             _statsD.Send<Statsd.Counting>(BuildNamespacedStatName(statName), value, sampleRate);
         }
 
-        public static void Gauge(string statName, double value)
+        /// <summary>
+        /// Emit gauge value to statsd
+        /// </summary>
+        /// <param name="statName"></param>
+        /// <param name="value"></param>
+        /// <param name="isDeltaValue">
+        /// When set to true the given value will be submitted as a delta value 
+        /// so the value is modified in statsd instead of set to the given value
+        /// </param>
+        public static void Gauge(string statName, double value, bool isDeltaValue=false)
         {
-            _statsD.Send<Statsd.Gauge>(BuildNamespacedStatName(statName), value);
+            if(isDeltaValue)
+                _statsD.Send<Statsd.Gauge>(BuildNamespacedStatName(statName), value, true);
+            else
+                _statsD.Send<Statsd.Gauge>(BuildNamespacedStatName(statName), value, false);
         }
 
         public static void Timer(string statName, int value, double sampleRate = 1)

--- a/src/StatsdClient/NullStatsd.cs
+++ b/src/StatsdClient/NullStatsd.cs
@@ -55,5 +55,9 @@ namespace StatsdClient
         {
             actionToTime();
         }
-    }
+
+        public void Send<TCommandType>(string name, double value, bool isDeltaValue) where TCommandType : IAllowsDouble, IAllowsDelta
+        {
+        }
+  }
 }

--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -75,9 +75,14 @@ namespace StatsdClient
         {
           if (isDeltaValue)
           {
+              // Sending delta values to StatsD requires a value modifier sign (+ or -) which we append 
+              // using this custom format with a different formatting rule for negative/positive and zero values
+              // https://msdn.microsoft.com/en-us/library/0c899ak8.aspx#SectionSeparator
+              const string deltaValueStringFormat = "{0:+#.###;-#.###;+0}";
               Commands = new List<string> {
-                GetCommand(name, string.Format(CultureInfo.InvariantCulture, "{0}{1:F15}", 
-                  (value >= 0 ? "+" : ""), value), //explicit appending of the + sign for delta, negative sign is added automatically if value is negative
+                GetCommand(name, string.Format(CultureInfo.InvariantCulture, 
+                deltaValueStringFormat, 
+                value), 
                   _commandToUnit[typeof(TCommandType)], 1)
               };
               Send();

--- a/src/Tests/MetricIntegrationTests.cs
+++ b/src/Tests/MetricIntegrationTests.cs
@@ -269,6 +269,15 @@ namespace Tests
             }
         }
 
+        public class GaugeDelta : MetricIntegrationTests
+        {
+
+        }
+        public class GaugeAbsoluteValue : MetricIntegrationTests
+        {
+
+        }
+
         public class Gauge : MetricIntegrationTests
         {
             [Test]

--- a/src/Tests/MetricIntegrationTests.cs
+++ b/src/Tests/MetricIntegrationTests.cs
@@ -271,11 +271,17 @@ namespace Tests
 
         public class GaugeDelta : MetricIntegrationTests
         {
+            [Test]
+            [TestCase(123d, "gauge:+123|g")]
+            [TestCase(-123d, "gauge:-123|g")]
+            [TestCase(0d, "gauge:+0|g")]
+            public void GaugeDelta_EmitsCorrect_Format(double gaugeDeltaValue, string expectedPacketMessageFormat)
+            {
+              Metrics.Configure(_defaultMetricsConfig);
 
-        }
-        public class GaugeAbsoluteValue : MetricIntegrationTests
-        {
-
+              Metrics.GaugeDelta("gauge", gaugeDeltaValue);
+              Assert.That(LastPacketMessageReceived(), Is.EqualTo(expectedPacketMessageFormat));
+            }
         }
 
         public class Gauge : MetricIntegrationTests

--- a/src/Tests/StatsdTests.cs
+++ b/src/Tests/StatsdTests.cs
@@ -241,6 +241,18 @@ namespace Tests
                 s.Send<Statsd.Gauge>("gauge", 5.0);
                 Assert.Pass();
             }
+
+            [Test]
+            [TestCase(true, 10d, "delta-gauge:+10.000000000000000|g")]
+            [TestCase(true, -10d, "delta-gauge:-10.000000000000000|g")]
+            [TestCase(true, 0d, "delta-gauge:+0.000000000000000|g")]
+            [TestCase(false, 10d, "delta-gauge:10.000000000000000|g")]
+            public void adds_gauge_with_deltaValue_formatsCorrectly(bool isDeltaValue, double value, string expectedFormattedStatsdMessage)
+            {
+                var s = new Statsd(_udp, _randomGenerator, _stopwatch);
+                s.Send<Statsd.Gauge>("delta-gauge", value, isDeltaValue);
+                _udp.AssertWasCalled(x => x.Send(expectedFormattedStatsdMessage));
+            }
         }
 
         public class Meter : StatsdTests

--- a/src/Tests/StatsdTests.cs
+++ b/src/Tests/StatsdTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using Rhino.Mocks;
 using StatsdClient;
+using Rhino.Mocks.Exceptions;
 
 namespace Tests
 {
@@ -243,10 +244,10 @@ namespace Tests
             }
 
             [Test]
-            [TestCase(true, 10d, "delta-gauge:+10.000000000000000|g")]
-            [TestCase(true, -10d, "delta-gauge:-10.000000000000000|g")]
-            [TestCase(true, 0d, "delta-gauge:+0.000000000000000|g")]
-            [TestCase(false, 10d, "delta-gauge:10.000000000000000|g")]
+            [TestCase(true, 10d, "delta-gauge:+10|g")]
+            [TestCase(true, -10d, "delta-gauge:-10|g")]
+            [TestCase(true, 0d, "delta-gauge:+0|g")]
+            [TestCase(false, 10d, "delta-gauge:10.000000000000000|g")]//because it is looped through to original Gauge send function
             public void adds_gauge_with_deltaValue_formatsCorrectly(bool isDeltaValue, double value, string expectedFormattedStatsdMessage)
             {
                 var s = new Statsd(_udp, _randomGenerator, _stopwatch);


### PR DESCRIPTION
Fix for #44 

I have added an extra Send method which takes a `IAllowsDelta` type and double+bool if you want to submit a delta value. I have left the original `Send` method intact for other Metric types which are allowed to send doubles but not delta's.

I have only created this implementation for the double datatypes because Gauges are configured only as `IAllowsDouble`.